### PR TITLE
Extend sandbox memory.

### DIFF
--- a/primitives/sandbox/embedded_executor.rs
+++ b/primitives/sandbox/embedded_executor.rs
@@ -52,6 +52,17 @@ impl Memory {
 		self.memref.set(ptr, value).map_err(|_| Error::OutOfBounds)?;
 		Ok(())
 	}
+
+	pub fn grow(&self, pages: u32) -> Result<u32, Error> {
+		self.memref
+			.grow(Pages(pages as usize))
+			.map(|prev| (prev.0 as u32))
+			.map_err(|_| Error::MemoryGrow)
+	}
+
+	pub fn size(&self) -> u32 {
+		self.memref.current_size().0 as u32
+	}
 }
 
 struct HostFuncIndex(usize);

--- a/primitives/sandbox/src/lib.rs
+++ b/primitives/sandbox/src/lib.rs
@@ -67,6 +67,9 @@ pub enum Error {
 	/// Note that if wasm module makes an out-of-bounds access then trap will occur.
 	OutOfBounds,
 
+	/// Trying to grow memory by more than maximum limit.
+	MemoryGrow,
+
 	/// Failed to invoke the start function or an exported function for some reason.
 	Execution,
 }
@@ -120,6 +123,20 @@ impl Memory {
 	/// Returns `Err` if the range is out-of-bounds.
 	pub fn set(&self, ptr: u32, value: &[u8]) -> Result<(), Error> {
 		self.inner.set(ptr, value)
+	}
+
+	/// Grow memory with provided number of pages.
+	///
+	/// Returns `Err` if attempted to allocate more memory than permited by the limit.
+	pub fn grow(&self, pages: u32) -> Result<u32, Error> {
+		self.inner.grow(pages)
+	}
+
+	/// Returns current memory size.
+	///
+	/// Maximum memory size cannot exceed 65536 pages or 4GiB.
+	pub fn size(&self) -> u32 {
+		self.inner.size()
 	}
 }
 


### PR DESCRIPTION
Add `grow` and `size` funcs to `sp_sandbox::Memory`.