### PR TITLE
add get_buff method to embedded executor memory

### DIFF
--- a/primitives/sandbox/src/embedded_executor.rs
+++ b/primitives/sandbox/src/embedded_executor.rs
@@ -68,6 +68,13 @@ impl super::SandboxMemory for Memory {
 	}
 }
 
+impl Memory {
+	/// Returns pointer to the begin of wasm mem buffer
+	pub unsafe fn get_buff(&self) -> *mut u8 {
+		self.memref.direct_access_mut().as_mut().as_mut_ptr()
+	}
+}
+
 struct HostFuncIndex(usize);
 
 struct DefinedHostFunctions<T> {

--- a/primitives/sandbox/src/lib.rs
+++ b/primitives/sandbox/src/lib.rs
@@ -115,7 +115,7 @@ pub trait SandboxMemory: Sized + Clone {
 	///
 	/// Returns `Err` if the range is out-of-bounds.
 	fn set(&self, ptr: u32, value: &[u8]) -> Result<(), Error>;
-	
+
 	/// Grow memory with provided number of pages.
 	///
 	/// Returns `Err` if attempted to allocate more memory than permited by the limit.


### PR DESCRIPTION
need to be able use this pointer in lazy-pages logic.

In nearest future I'm going to add this method to Sandbox trait, but currently it's needed only in embedded memory