### PR TITLE
add gear runtime support to use host executor sandbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,9 +1725,9 @@ checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
 
 [[package]]
 name = "dynasm"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc2d9a5e44da60059bd38db2d05cbb478619541b8c79890547861ec1e3194f0"
+checksum = "47b1801e630bd336d0bbbdbf814de6cc749c9a400c7e3d995e6adfd455d0c83c"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -1740,13 +1740,13 @@ dependencies = [
 
 [[package]]
 name = "dynasmrt"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42276e3f205fe63887cca255aa9a65a63fb72764c30b9a6252a7c7e46994f689"
+checksum = "1d428afc93ad288f6dffc1fa5f4a78201ad2eec33c5a522e51c181009eb09061"
 dependencies = [
  "byteorder",
  "dynasm",
- "memmap2 0.2.1",
+ "memmap2 0.5.0",
 ]
 
 [[package]]

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -271,8 +271,6 @@ try-runtime = [
 # Make contract callable functions marked as __unstable__ available. Do not enable
 # on live chains as those are subject to change.
 contracts-unstable-interface = ["pallet-contracts/unstable-interface"]
-# Force `sp-sandbox` to call into the host resident executor. One still need to make sure
-# that `sc-executor` gets the `wasmer-sandbox` feature which happens automatically when
-# specified on the command line.
-# Don't use that on a production chain.
-wasmer-sandbox = ["sp-sandbox/wasmer-sandbox"]
+# Force `sp-sandbox` to call into the host resident executor.
+# Don't use that on a production chain, when sc-executor use wasmer-sandbox.
+host-sandbox = ["sp-sandbox/host-sandbox"]

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -135,6 +135,11 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 		Ok(self.shared_params().is_dev())
 	}
 
+	/// Returns `true` if the node must use default execution strategies even in dev mode.
+	fn is_use_default_exec_strateg(&self) -> Result<bool> {
+		Ok(self.shared_params().is_use_default_exec_strateg())
+	}
+
 	/// Gets the role
 	///
 	/// By default this is `Role::Full`.
@@ -304,11 +309,12 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 	fn execution_strategies(
 		&self,
 		is_dev: bool,
+		is_use_default_exec_strateg: bool,
 		is_validator: bool,
 	) -> Result<ExecutionStrategies> {
 		Ok(self
 			.import_params()
-			.map(|x| x.execution_strategies(is_dev, is_validator))
+			.map(|x| x.execution_strategies(is_dev, is_use_default_exec_strateg, is_validator))
 			.unwrap_or_default())
 	}
 
@@ -477,6 +483,7 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 		tokio_handle: tokio::runtime::Handle,
 	) -> Result<Configuration> {
 		let is_dev = self.is_dev()?;
+		let is_use_default_exec_strateg = self.is_use_default_exec_strateg()?;
 		let chain_id = self.chain_id(is_dev)?;
 		let chain_spec = cli.load_spec(&chain_id)?;
 		let base_path = self
@@ -522,7 +529,11 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 			transaction_storage: self.database_transaction_storage()?,
 			wasm_method: self.wasm_method()?,
 			wasm_runtime_overrides: self.wasm_runtime_overrides(),
-			execution_strategies: self.execution_strategies(is_dev, is_validator)?,
+			execution_strategies: self.execution_strategies(
+				is_dev,
+				is_use_default_exec_strateg,
+				is_validator,
+			)?,
 			rpc_http: self.rpc_http(DCV::rpc_http_listen_port())?,
 			rpc_ws: self.rpc_ws(DCV::rpc_ws_listen_port())?,
 			rpc_ipc: self.rpc_ipc()?,
@@ -658,7 +669,7 @@ pub fn generate_node_name() -> String {
 		let count = node_name.chars().count();
 
 		if count < NODE_NAME_MAX_LENGTH {
-			return node_name
+			return node_name;
 		}
 	}
 }

--- a/client/cli/src/params/import_params.rs
+++ b/client/cli/src/params/import_params.rs
@@ -96,10 +96,14 @@ impl ImportParams {
 	}
 
 	/// Get execution strategies for the parameters
-	pub fn execution_strategies(&self, is_dev: bool, is_validator: bool) -> ExecutionStrategies {
+	pub fn execution_strategies(&self, is_dev: bool, is_use_default_exec_strateg: bool, is_validator: bool) -> ExecutionStrategies {
 		let exec = &self.execution_strategies;
 		let exec_all_or = |strat: Option<ExecutionStrategy>, default: ExecutionStrategy| {
-			let default = if is_dev { ExecutionStrategy::Native } else { default };
+			let default = if is_use_default_exec_strateg || !is_dev {
+				default
+			} else {
+				ExecutionStrategy::Native
+			};
 
 			exec.execution.unwrap_or_else(|| strat.unwrap_or(default)).into()
 		};

--- a/client/cli/src/params/shared_params.rs
+++ b/client/cli/src/params/shared_params.rs
@@ -38,6 +38,10 @@ pub struct SharedParams {
 	#[clap(long, conflicts_with_all = &["chain"])]
 	pub dev: bool,
 
+	/// Use default execution strategies even if is dev node.
+	#[clap(long)]
+	pub use_default_exec_strateg: bool,
+
 	/// Specify custom base path.
 	#[clap(long, short = 'd', value_name = "PATH", parse(from_os_str))]
 	pub base_path: Option<PathBuf>,
@@ -89,6 +93,11 @@ impl SharedParams {
 	/// Specify the development chain.
 	pub fn is_dev(&self) -> bool {
 		self.dev
+	}
+
+	/// Specify whether use default execution strategies, even in dev node.
+	pub fn is_use_default_exec_strateg(&self) -> bool {
+		self.use_default_exec_strateg
 	}
 
 	/// Get the chain spec for the parameters provided

--- a/client/executor/common/src/sandbox.rs
+++ b/client/executor/common/src/sandbox.rs
@@ -399,6 +399,33 @@ impl util::MemoryTransfer for Memory {
 			Memory::Wasmer(sandboxed_memory) => sandboxed_memory.write_from(dest_addr, source),
 		}
 	}
+
+	fn memory_grow(&mut self, pages: u32) -> Result<u32> {
+		match self {
+			Memory::Wasmi(sandboxed_memory) => sandboxed_memory.memory_grow(pages),
+
+			#[cfg(feature = "wasmer-sandbox")]
+			Memory::Wasmer(sandboxed_memory) => sandboxed_memory.memory_grow(pages),
+		}
+	}
+
+	fn memory_size(&mut self) -> u32 {
+		match self {
+			Memory::Wasmi(sandboxed_memory) => sandboxed_memory.memory_size(),
+
+			#[cfg(feature = "wasmer-sandbox")]
+			Memory::Wasmer(sandboxed_memory) => sandboxed_memory.memory_size(),
+		}
+	}
+
+	fn get_buff(&mut self) -> *mut u8 {
+		match self {
+			Memory::Wasmi(sandboxed_memory) => sandboxed_memory.get_buff(),
+
+			#[cfg(feature = "wasmer-sandbox")]
+			Memory::Wasmer(sandboxed_memory) => sandboxed_memory.get_buff(),
+		}
+	}
 }
 
 /// Information specific to a particular execution backend

--- a/client/executor/common/src/sandbox/wasmer_backend.rs
+++ b/client/executor/common/src/sandbox/wasmer_backend.rs
@@ -85,11 +85,12 @@ pub fn invoke(
 				wasmer::Val::I64(val) => Value::I64(val),
 				wasmer::Val::F32(val) => Value::F32(f32::to_bits(val)),
 				wasmer::Val::F64(val) => Value::F64(f64::to_bits(val)),
-				_ =>
+				_ => {
 					return Err(Error::Sandbox(format!(
 						"Unsupported return value: {:?}",
 						wasm_value,
-					))),
+					)))
+				},
 			};
 
 			Ok(Some(wasmer_value))
@@ -160,7 +161,7 @@ pub fn instantiate(
 					index
 				} else {
 					// Missing import (should we abort here?)
-					continue
+					continue;
 				};
 
 				let supervisor_func_index = guest_env
@@ -189,8 +190,9 @@ pub fn instantiate(
 		wasmer::Instance::new(&module, &import_object).map_err(|error| match error {
 			wasmer::InstantiationError::Link(_) => InstantiationError::Instantiation,
 			wasmer::InstantiationError::Start(_) => InstantiationError::StartTrapped,
-			wasmer::InstantiationError::HostEnvInitialization(_) =>
-				InstantiationError::EnvironmentDefinitionCorrupted,
+			wasmer::InstantiationError::HostEnvInitialization(_) => {
+				InstantiationError::EnvironmentDefinitionCorrupted
+			},
 		})
 	})?;
 
@@ -216,8 +218,9 @@ fn dispatch_function(
 					wasmer::Val::I64(val) => Ok(Value::I64(*val)),
 					wasmer::Val::F32(val) => Ok(Value::F32(f32::to_bits(*val))),
 					wasmer::Val::F64(val) => Ok(Value::F64(f64::to_bits(*val))),
-					_ =>
-						Err(RuntimeError::new(format!("Unsupported function argument: {:?}", val))),
+					_ => {
+						Err(RuntimeError::new(format!("Unsupported function argument: {:?}", val)))
+					},
 				})
 				.collect::<std::result::Result<Vec<_>, _>>()?
 				.encode();
@@ -245,7 +248,7 @@ fn dispatch_function(
 					"Failed dealloction after failed write of invoke arguments",
 				)?;
 
-				return Err(RuntimeError::new("Can't write invoke args into memory"))
+				return Err(RuntimeError::new("Can't write invoke args into memory"));
 			}
 
 			// Perform the actuall call
@@ -430,5 +433,24 @@ impl MemoryTransfer for MemoryWrapper {
 			destination[range].copy_from_slice(source);
 			Ok(())
 		}
+	}
+
+	fn memory_grow(&mut self, pages: u32) -> Result<u32> {
+		let memory = &mut self.buffer.borrow_mut();
+		memory
+			.grow(pages)
+			.map_err(|e| {
+				Error::Sandbox(format!("Connot grow memory in wasmer sandbox executor: {}", e))
+			})
+			.map(|p| p.0)
+	}
+
+	fn memory_size(&mut self) -> u32 {
+		let memory = &mut self.buffer.borrow_mut();
+		memory.size().0
+	}
+
+	fn get_buff(&mut self) -> *mut u8 {
+		self.buffer.borrow_mut().data_ptr()
 	}
 }

--- a/client/executor/common/src/sandbox/wasmi_backend.rs
+++ b/client/executor/common/src/sandbox/wasmi_backend.rs
@@ -29,7 +29,7 @@ use wasmi::{
 };
 
 use crate::{
-	error::{self, Error},
+	error::{self, Error, Result},
 	sandbox::{
 		BackendInstance, GuestEnvironment, GuestExternals, GuestFuncIndex, Imports,
 		InstantiationError, Memory, SandboxContext, SandboxInstance,
@@ -153,6 +153,21 @@ impl MemoryTransfer for MemoryWrapper {
 			destination[range].copy_from_slice(source);
 			Ok(())
 		})
+	}
+
+	fn memory_grow(&mut self, pages: u32) -> Result<u32> {
+		self.0
+			.grow(Pages(pages as usize))
+			.map_err(|e| Error::Sandbox(format!("Cannot grow memory in masmi sandbox executor: {}", e)))
+			.map(|p| p.0 as u32)
+	}
+
+	fn memory_size(&mut self) -> u32 {
+		self.0.current_size().0 as u32
+	}
+
+	fn get_buff(&mut self) -> *mut u8 {
+		self.0.direct_access_mut().as_mut().as_mut_ptr()
 	}
 }
 

--- a/client/executor/common/src/util.rs
+++ b/client/executor/common/src/util.rs
@@ -49,4 +49,15 @@ pub trait MemoryTransfer {
 	///
 	/// Returns an error if the write would go out of the memory bounds.
 	fn write_from(&self, dest_addr: Pointer<u8>, source: &[u8]) -> Result<()>;
+
+	/// Grow memory by `pages`.
+	///
+	/// Returns memory prev size.
+	fn memory_grow(&mut self, pages: u32) -> Result<u32>;
+
+	/// Returns memory size in pages.
+	fn memory_size(&mut self) -> u32;
+
+	/// Returns host pointer to the wasm memory buffer.
+	fn get_buff(&mut self) -> *mut u8;
 }

--- a/client/executor/wasmi/src/lib.rs
+++ b/client/executor/wasmi/src/lib.rs
@@ -160,7 +160,7 @@ impl Sandbox for FunctionExecutor {
 		};
 
 		if let Err(_) = self.memory.set(buf_ptr.into(), &buffer) {
-			return Ok(sandbox_primitives::ERR_OUT_OF_BOUNDS)
+			return Ok(sandbox_primitives::ERR_OUT_OF_BOUNDS);
 		}
 
 		Ok(sandbox_primitives::ERR_OK)
@@ -184,7 +184,7 @@ impl Sandbox for FunctionExecutor {
 		};
 
 		if let Err(_) = sandboxed_memory.write_from(Pointer::new(offset as u32), &buffer) {
-			return Ok(sandbox_primitives::ERR_OUT_OF_BOUNDS)
+			return Ok(sandbox_primitives::ERR_OUT_OF_BOUNDS);
 		}
 
 		Ok(sandbox_primitives::ERR_OK)
@@ -312,6 +312,33 @@ impl Sandbox for FunctionExecutor {
 			.map(|i| i.get_global_val(name))
 			.map_err(|e| e.to_string())
 	}
+
+	fn memory_grow(&mut self, memory_id: MemoryId, pages: u32) -> WResult<u32> {
+		let mut m = self
+			.sandbox_store
+			.borrow_mut()
+			.memory(memory_id)
+			.map_err(|e| format!("Cannot get wasmi memory: {}", e))?;
+		m.memory_grow(pages).map_err(|e| format!("{}", e))
+	}
+
+	fn memory_size(&mut self, memory_id: MemoryId) -> WResult<u32> {
+		let mut m = self
+			.sandbox_store
+			.borrow_mut()
+			.memory(memory_id)
+			.map_err(|e| format!("Cannot get wasmi memory: {}", e))?;
+		Ok(m.memory_size())
+	}
+
+	fn get_buff(&mut self, memory_id: MemoryId) -> WResult<*mut u8> {
+		let mut m = self
+			.sandbox_store
+			.borrow_mut()
+			.memory(memory_id)
+			.map_err(|e| format!("Cannot get wasmi memory: {}", e))?;
+		Ok(m.get_buff())
+	}
 }
 
 /// Will be used on initialization of a module to resolve function and memory imports.
@@ -358,14 +385,14 @@ impl<'a> wasmi::ModuleImportResolver for Resolver<'a> {
 		for (function_index, function) in self.host_functions.iter().enumerate() {
 			if name == function.name() {
 				if signature == function.signature() {
-					return Ok(wasmi::FuncInstance::alloc_host(signature.into(), function_index))
+					return Ok(wasmi::FuncInstance::alloc_host(signature.into(), function_index));
 				} else {
 					return Err(wasmi::Error::Instantiation(format!(
 						"Invalid signature for function `{}` expected `{:?}`, got `{:?}`",
 						function.name(),
 						signature,
 						function.signature(),
-					)))
+					)));
 				}
 			}
 		}
@@ -388,8 +415,9 @@ impl<'a> wasmi::ModuleImportResolver for Resolver<'a> {
 	) -> Result<MemoryRef, wasmi::Error> {
 		if field_name == "memory" {
 			match &mut *self.import_memory.borrow_mut() {
-				Some(_) =>
-					Err(wasmi::Error::Instantiation("Memory can not be imported twice!".into())),
+				Some(_) => {
+					Err(wasmi::Error::Instantiation("Memory can not be imported twice!".into()))
+				},
 				memory_ref @ None => {
 					if memory_type
 						.maximum()
@@ -438,9 +466,9 @@ impl wasmi::Externals for FunctionExecutor {
 				.map_err(|msg| Error::FunctionExecution(function.name().to_string(), msg))
 				.map_err(wasmi::Trap::from)
 				.map(|v| v.map(Into::into))
-		} else if self.allow_missing_func_imports &&
-			index >= self.host_functions.len() &&
-			index < self.host_functions.len() + self.missing_functions.len()
+		} else if self.allow_missing_func_imports
+			&& index >= self.host_functions.len()
+			&& index < self.host_functions.len() + self.missing_functions.len()
 		{
 			Err(Error::from(format!(
 				"Function `{}` is only a stub. Calling a stub is not allowed.",

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -1564,6 +1564,24 @@ pub trait Sandbox {
 			.get_global_val(instance_idx, name)
 			.expect("Failed to get global from sandbox")
 	}
+
+	fn memory_grow(&mut self, memory_idx: u32, size: u32) -> u32 {
+		self.sandbox()
+			.memory_grow(memory_idx, size)
+			.expect("Failed to grow memory from sandbox")
+	}
+
+	fn memory_size(&mut self, memory_idx: u32) -> u32 {
+		self.sandbox()
+			.memory_size(memory_idx)
+			.expect("Failed to get memory size from sandbox")
+	}
+
+	fn get_buff(&mut self, memory_idx: u32) -> u64 {
+		self.sandbox()
+			.get_buff(memory_idx)
+			.expect("Failed to get wasmo memory buffer addr from sandbox") as u64
+	}
 }
 
 /// Wasm host functions for managing tasks.

--- a/primitives/sandbox/Cargo.toml
+++ b/primitives/sandbox/Cargo.toml
@@ -43,4 +43,4 @@ std = [
 	"log/std",
 ]
 strict = []
-wasmer-sandbox = []
+host-sandbox = []

--- a/primitives/sandbox/src/embedded_executor.rs
+++ b/primitives/sandbox/src/embedded_executor.rs
@@ -66,12 +66,9 @@ impl super::SandboxMemory for Memory {
 	fn size(&self) -> u32 {
 		self.memref.current_size().0 as u32
 	}
-}
 
-impl Memory {
-	/// Returns pointer to the begin of wasm mem buffer
-	pub unsafe fn get_buff(&self) -> *mut u8 {
-		self.memref.direct_access_mut().as_mut().as_mut_ptr()
+	unsafe fn get_buff(&self) -> u64 {
+		self.memref.direct_access_mut().as_mut().as_mut_ptr() as usize as u64
 	}
 }
 
@@ -187,7 +184,7 @@ impl<T> ImportResolver for EnvironmentDefinitionBuilder<T> {
 			ExternVal::HostFunc(ref idx) => idx,
 			_ => {
 				debug!(target: TARGET, "Export {}:{} is not a host func", module_name, field_name);
-				return Err(wasmi::Error::Instantiation(String::new()))
+				return Err(wasmi::Error::Instantiation(String::new()));
 			},
 		};
 		Ok(FuncInstance::alloc_host(signature.clone(), host_func_idx.0))
@@ -218,7 +215,7 @@ impl<T> ImportResolver for EnvironmentDefinitionBuilder<T> {
 			ExternVal::Memory(ref m) => m,
 			_ => {
 				debug!(target: TARGET, "Export {}:{} is not a memory", module_name, field_name);
-				return Err(wasmi::Error::Instantiation(String::new()))
+				return Err(wasmi::Error::Instantiation(String::new()));
 			},
 		};
 		Ok(memory.memref.clone())
@@ -321,7 +318,7 @@ mod tests {
 
 		fn env_assert(_e: &mut State, args: &[Value]) -> Result<ReturnValue, HostError> {
 			if args.len() != 1 {
-				return Err(HostError)
+				return Err(HostError);
 			}
 			let condition = args[0].as_i32().ok_or_else(|| HostError)?;
 			if condition != 0 {
@@ -332,7 +329,7 @@ mod tests {
 		}
 		fn env_inc_counter(e: &mut State, args: &[Value]) -> Result<ReturnValue, HostError> {
 			if args.len() != 1 {
-				return Err(HostError)
+				return Err(HostError);
 			}
 			let inc_by = args[0].as_i32().ok_or_else(|| HostError)?;
 			e.counter += inc_by as u32;
@@ -341,7 +338,7 @@ mod tests {
 		/// Function that takes one argument of any type and returns that value.
 		fn env_polymorphic_id(_e: &mut State, args: &[Value]) -> Result<ReturnValue, HostError> {
 			if args.len() != 1 {
-				return Err(HostError)
+				return Err(HostError);
 			}
 			Ok(ReturnValue::Value(args[0]))
 		}

--- a/primitives/sandbox/src/host_executor.rs
+++ b/primitives/sandbox/src/host_executor.rs
@@ -102,11 +102,17 @@ impl super::SandboxMemory for Memory {
 	}
 
 	fn grow(&self, pages: u32) -> Result<u32, Error> {
-		todo!()
+		let size = self.size();
+		sandbox::memory_grow(self.handle.memory_idx, pages);
+		Ok(size)
 	}
 
 	fn size(&self) -> u32 {
-		todo!()
+		sandbox::memory_size(self.handle.memory_idx)
+	}
+
+	unsafe fn get_buff(&self) -> u64 {
+		sandbox::get_buff(self.handle.memory_idx)
 	}
 }
 

--- a/primitives/sandbox/src/lib.rs
+++ b/primitives/sandbox/src/lib.rs
@@ -52,10 +52,10 @@ pub mod embedded_executor;
 #[cfg(not(feature = "std"))]
 pub mod host_executor;
 
-#[cfg(all(feature = "wasmer-sandbox", not(feature = "std")))]
+#[cfg(all(feature = "host-sandbox", not(feature = "std")))]
 pub use host_executor as default_executor;
 
-#[cfg(not(all(feature = "wasmer-sandbox", not(feature = "std"))))]
+#[cfg(not(all(feature = "host-sandbox", not(feature = "std"))))]
 pub use embedded_executor as default_executor;
 
 /// Error that can occur while using this crate.
@@ -125,6 +125,9 @@ pub trait SandboxMemory: Sized + Clone {
 	///
 	/// Maximum memory size cannot exceed 65536 pages or 4GiB.
 	fn size(&self) -> u32;
+
+	/// Returns pointer to the begin of wasm mem buffer
+	unsafe fn get_buff(&self) -> u64;
 }
 
 /// Struct that can be used for defining an environment for a sandboxed module.

--- a/primitives/wasm-interface/src/lib.rs
+++ b/primitives/wasm-interface/src/lib.rs
@@ -382,6 +382,15 @@ pub trait Sandbox {
 	///
 	/// Returns `Some(_)` when the requested global variable could be found.
 	fn get_global_val(&self, instance_idx: u32, name: &str) -> Result<Option<Value>>;
+
+	/// Returns size in wasm pages of memory with id `memory_id`.
+	fn memory_size(&mut self, memory_id: MemoryId) -> Result<u32>;
+
+	/// Tries to grow memory size by `pages_num`. Returns memory previous size.
+	fn memory_grow(&mut self, memory_id: MemoryId, pages_num: u32) -> Result<u32>;
+
+	/// Get host pointer to the begin of wasm memory with `memory_id`.
+	fn get_buff(&mut self, memory_id: MemoryId) -> Result<*mut u8>;
 }
 
 if_wasmtime_is_enabled! {


### PR DESCRIPTION
1) add grow/size/get_buff runtime interfaces, which allows to operate with host sandbox from gear runtime.
2) add new cli argument: use_default_exec_strateg, which forces node to use default execution strategy even in dev mode.
3) rename wasmer-sandbox feature, to host-sandbox feature.