### PR TITLE
add virtual_memory feature for wasmi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11650,6 +11650,7 @@ dependencies = [
  "num-rational 0.4.0",
  "num-traits",
  "parity-wasm 0.42.2",
+ "region 3.0.0",
  "wasmi-validation",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8193,7 +8193,7 @@ dependencies = [
  "tempfile",
  "tracing",
  "tracing-subscriber",
- "wasmi 0.9.1",
+ "wasmi",
  "wat",
 ]
 
@@ -8214,7 +8214,7 @@ dependencies = [
  "wasmer",
  "wasmer-cache",
  "wasmer-compiler",
- "wasmi 0.11.0",
+ "wasmi",
 ]
 
 [[package]]
@@ -8228,7 +8228,7 @@ dependencies = [
  "sp-runtime-interface",
  "sp-sandbox",
  "sp-wasm-interface",
- "wasmi 0.11.0",
+ "wasmi",
 ]
 
 [[package]]
@@ -9671,7 +9671,7 @@ dependencies = [
  "substrate-bip39",
  "thiserror",
  "tiny-bip39",
- "wasmi 0.11.0",
+ "wasmi",
  "zeroize",
 ]
 
@@ -9996,7 +9996,7 @@ dependencies = [
  "sp-io",
  "sp-std",
  "sp-wasm-interface",
- "wasmi 0.11.0",
+ "wasmi",
  "wat",
 ]
 
@@ -10201,7 +10201,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "sp-std",
- "wasmi 0.11.0",
+ "wasmi",
  "wasmtime",
 ]
 
@@ -11620,22 +11620,6 @@ dependencies = [
  "thiserror",
  "wasmer-types",
  "winapi",
-]
-
-[[package]]
-name = "wasmi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca00c5147c319a8ec91ec1a0edbec31e566ce2c9cc93b3f9bb86a9efd0eb795d"
-dependencies = [
- "downcast-rs",
- "errno",
- "libc",
- "memory_units",
- "num-rational 0.2.4",
- "num-traits",
- "parity-wasm 0.42.2",
- "wasmi-validation",
 ]
 
 [[package]]

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -148,7 +148,6 @@ pallet-balances = { version = "4.0.0-dev", path = "../../../frame/balances" }
 [features]
 default = ["cli"]
 cli = [
-	"node-executor/wasmi-errno",
 	"node-inspect",
 	"sc-cli",
 	"frame-benchmarking-cli",

--- a/bin/node/executor/Cargo.toml
+++ b/bin/node/executor/Cargo.toml
@@ -44,7 +44,6 @@ sp-runtime = { version = "6.0.0", path = "../../../primitives/runtime" }
 
 [features]
 wasmtime = ["sc-executor/wasmtime"]
-wasmi-errno = ["sc-executor/wasmi-errno"]
 stress-test = []
 
 [[bench]]

--- a/client/executor/Cargo.toml
+++ b/client/executor/Cargo.toml
@@ -18,7 +18,7 @@ lazy_static = "1.4.0"
 lru = "0.7.5"
 parking_lot = "0.12.0"
 tracing = "0.1.29"
-wasmi = "0.9.1"
+wasmi = { version = "0.11", features = ["virtual_memory"] }
 
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 sc-executor-common = { version = "0.10.0-dev", path = "common" }
@@ -63,6 +63,5 @@ default = ["std"]
 std = []
 wasm-extern-trace = []
 wasmtime = ["sc-executor-wasmtime"]
-wasmi-errno = ["wasmi/errno"]
 wasmer-sandbox = ["sc-executor-common/wasmer-sandbox"]
 wasmer-cache = ["sc-executor-common/wasmer-cache"]

--- a/client/executor/common/Cargo.toml
+++ b/client/executor/common/Cargo.toml
@@ -18,7 +18,7 @@ codec = { package = "parity-scale-codec", version = "3.0.0" }
 environmental = "1.1.3"
 thiserror = "1.0.30"
 wasm-instrument = "0.1.0"
-wasmi = "0.11"
+wasmi = { version = "0.11", features = ["virtual_memory"] }
 sc-allocator = { version = "4.1.0-dev", path = "../../allocator" }
 sp-maybe-compressed-blob = { version = "4.1.0-dev", path = "../../../primitives/maybe-compressed-blob" }
 sp-sandbox = { version = "0.10.0-dev", path = "../../../primitives/sandbox" }

--- a/client/executor/wasmi/Cargo.toml
+++ b/client/executor/wasmi/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 log = "0.4.17"
-wasmi = "0.11"
+wasmi = { version = "0.11", features = ["virtual_memory"] }
 sc-allocator = { version = "4.1.0-dev", path = "../../allocator" }
 sc-executor-common = { version = "0.10.0-dev", path = "../common" }
 sp-runtime-interface = { version = "6.0.0", path = "../../../primitives/runtime-interface" }

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0.136", optional = true, features = ["derive"] }
 byteorder = { version = "1.3.2", default-features = false }
 primitive-types = { version = "0.11.1", default-features = false, features = ["codec", "scale-info"] }
 impl-serde = { version = "0.3.0", optional = true }
-wasmi = { version = "0.11", optional = true }
+wasmi = { version = "0.11", optional = true, features = ["virtual_memory"] }
 hash-db = { version = "0.15.2", default-features = false }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
 base58 = { version = "0.2.0", optional = true }

--- a/primitives/sandbox/Cargo.toml
+++ b/primitives/sandbox/Cargo.toml
@@ -16,12 +16,11 @@ targets = ["x86_64-unknown-linux-gnu"]
 wasmi = { version = "0.11", default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-wasmi = "0.11"
+wasmi = { version = "0.11", features = ["virtual_memory"] }
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
 log = { version = "0.4", default-features = false }
-wasmi = { version = "0.11", optional = true }
 sp-core = { version = "6.0.0", default-features = false, path = "../core" }
 sp-io = { version = "6.0.0", default-features = false, path = "../io" }
 sp-std = { version = "4.0.0", default-features = false, path = "../std" }
@@ -40,7 +39,6 @@ std = [
 	"sp-io/std",
 	"sp-std/std",
 	"sp-wasm-interface/std",
-	"wasmi",
 ]
 strict = []
 host-sandbox = []

--- a/primitives/wasm-interface/Cargo.toml
+++ b/primitives/wasm-interface/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 impl-trait-for-tuples = "0.2.2"
 log = { version = "0.4.17", optional = true }
-wasmi = { version = "0.11", optional = true }
+wasmi = { version = "0.11", optional = true, features = ["virtual_memory"] }
 wasmtime = { version = "0.35.3", default-features = false, optional = true }
 sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 


### PR DESCRIPTION
in other case wasmi uses vec as memory buffer, which cause unaligned mem buffer addr, which cannot be used in lazy-pages 