### PR TITLE
Extend sanbox memory

### DIFF
--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -294,8 +294,6 @@ try-runtime = [
 # Make contract callable functions marked as __unstable__ available. Do not enable
 # on live chains as those are subject to change.
 contracts-unstable-interface = ["pallet-contracts/unstable-interface"]
-# Force `sp-sandbox` to call into the host resident executor. One still need to make sure
-# that `sc-executor` gets the `wasmer-sandbox` feature which happens automatically when
-# specified on the command line.
-# Don't use that on a production chain.
-wasmer-sandbox = ["sp-sandbox/wasmer-sandbox"]
+# Force `sp-sandbox` to call into the host resident executor.
+# Don't use that on a production chain, when sc-executor use wasmer-sandbox.
+host-sandbox = ["sp-sandbox/host-sandbox"]

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -135,6 +135,11 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 		Ok(self.shared_params().is_dev())
 	}
 
+	/// Returns `true` if the node must use default execution strategies even in dev mode.
+	fn is_use_default_exec_strateg(&self) -> Result<bool> {
+		Ok(self.shared_params().is_use_default_exec_strateg())
+	}
+
 	/// Gets the role
 	///
 	/// By default this is `Role::Full`.
@@ -304,11 +309,12 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 	fn execution_strategies(
 		&self,
 		is_dev: bool,
+		is_use_default_exec_strateg: bool,
 		is_validator: bool,
 	) -> Result<ExecutionStrategies> {
 		Ok(self
 			.import_params()
-			.map(|x| x.execution_strategies(is_dev, is_validator))
+			.map(|x| x.execution_strategies(is_dev, is_use_default_exec_strateg, is_validator))
 			.unwrap_or_default())
 	}
 
@@ -492,6 +498,7 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 		tokio_handle: tokio::runtime::Handle,
 	) -> Result<Configuration> {
 		let is_dev = self.is_dev()?;
+		let is_use_default_exec_strateg = self.is_use_default_exec_strateg()?;
 		let chain_id = self.chain_id(is_dev)?;
 		let chain_spec = cli.load_spec(&chain_id)?;
 		let base_path = self
@@ -543,7 +550,11 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 			keep_blocks: self.keep_blocks()?,
 			wasm_method: self.wasm_method()?,
 			wasm_runtime_overrides: self.wasm_runtime_overrides(),
-			execution_strategies: self.execution_strategies(is_dev, is_validator)?,
+			execution_strategies: self.execution_strategies(
+				is_dev,
+				is_use_default_exec_strateg,
+				is_validator,
+			)?,
 			rpc_http: self.rpc_http(DCV::rpc_http_listen_port())?,
 			rpc_ws: self.rpc_ws(DCV::rpc_ws_listen_port())?,
 			rpc_ipc: self.rpc_ipc()?,
@@ -694,7 +705,7 @@ pub fn generate_node_name() -> String {
 		let count = node_name.chars().count();
 
 		if count < NODE_NAME_MAX_LENGTH {
-			return node_name
+			return node_name;
 		}
 	}
 }

--- a/client/cli/src/params/import_params.rs
+++ b/client/cli/src/params/import_params.rs
@@ -117,10 +117,14 @@ impl ImportParams {
 	}
 
 	/// Get execution strategies for the parameters
-	pub fn execution_strategies(&self, is_dev: bool, is_validator: bool) -> ExecutionStrategies {
+	pub fn execution_strategies(&self, is_dev: bool, is_use_default_exec_strateg: bool, is_validator: bool) -> ExecutionStrategies {
 		let exec = &self.execution_strategies;
 		let exec_all_or = |strat: Option<ExecutionStrategy>, default: ExecutionStrategy| {
-			let default = if is_dev { ExecutionStrategy::Native } else { default };
+			let default = if is_use_default_exec_strateg || !is_dev {
+				default
+			} else {
+				ExecutionStrategy::Native
+			};
 
 			exec.execution.unwrap_or_else(|| strat.unwrap_or(default)).into()
 		};

--- a/client/cli/src/params/shared_params.rs
+++ b/client/cli/src/params/shared_params.rs
@@ -38,6 +38,10 @@ pub struct SharedParams {
 	#[clap(long, conflicts_with_all = &["chain"])]
 	pub dev: bool,
 
+	/// Use default execution strategies even if is dev node.
+	#[clap(long)]
+	pub use_default_exec_strateg: bool,
+
 	/// Specify custom base path.
 	#[clap(long, short = 'd', value_name = "PATH", parse(from_os_str))]
 	pub base_path: Option<PathBuf>,
@@ -89,6 +93,11 @@ impl SharedParams {
 	/// Specify the development chain.
 	pub fn is_dev(&self) -> bool {
 		self.dev
+	}
+
+	/// Specify whether use default execution strategies, even in dev node.
+	pub fn is_use_default_exec_strateg(&self) -> bool {
+		self.use_default_exec_strateg
 	}
 
 	/// Get the chain spec for the parameters provided

--- a/client/executor/common/src/sandbox.rs
+++ b/client/executor/common/src/sandbox.rs
@@ -385,6 +385,33 @@ impl util::MemoryTransfer for Memory {
 			Memory::Wasmer(sandboxed_memory) => sandboxed_memory.write_from(dest_addr, source),
 		}
 	}
+
+	fn memory_grow(&mut self, pages: u32) -> Result<u32> {
+		match self {
+			Memory::Wasmi(sandboxed_memory) => sandboxed_memory.memory_grow(pages),
+
+			#[cfg(feature = "wasmer-sandbox")]
+			Memory::Wasmer(sandboxed_memory) => sandboxed_memory.memory_grow(pages),
+		}
+	}
+
+	fn memory_size(&mut self) -> u32 {
+		match self {
+			Memory::Wasmi(sandboxed_memory) => sandboxed_memory.memory_size(),
+
+			#[cfg(feature = "wasmer-sandbox")]
+			Memory::Wasmer(sandboxed_memory) => sandboxed_memory.memory_size(),
+		}
+	}
+
+	fn get_buff(&mut self) -> *mut u8 {
+		match self {
+			Memory::Wasmi(sandboxed_memory) => sandboxed_memory.get_buff(),
+
+			#[cfg(feature = "wasmer-sandbox")]
+			Memory::Wasmer(sandboxed_memory) => sandboxed_memory.get_buff(),
+		}
+	}
 }
 
 /// Information specific to a particular execution backend

--- a/client/executor/common/src/sandbox/wasmer_backend.rs
+++ b/client/executor/common/src/sandbox/wasmer_backend.rs
@@ -432,6 +432,25 @@ impl MemoryTransfer for MemoryWrapper {
 			Ok(())
 		}
 	}
+
+	fn memory_grow(&mut self, pages: u32) -> Result<u32> {
+		let memory = &mut self.buffer.borrow_mut();
+		memory
+			.grow(pages)
+			.map_err(|e| {
+				Error::Sandbox(format!("Cannot grow memory in wasmer sandbox executor: {}", e))
+			})
+			.map(|p| p.0)
+	}
+
+	fn memory_size(&mut self) -> u32 {
+		let memory = &mut self.buffer.borrow_mut();
+		memory.size().0
+	}
+
+	fn get_buff(&mut self) -> *mut u8 {
+		self.buffer.borrow_mut().data_ptr()
+	}
 }
 
 /// Get global value by name

--- a/client/executor/common/src/sandbox/wasmi_backend.rs
+++ b/client/executor/common/src/sandbox/wasmi_backend.rs
@@ -29,7 +29,7 @@ use wasmi::{
 };
 
 use crate::{
-	error::{self, Error},
+	error::{self, Error, Result},
 	sandbox::{
 		BackendInstance, GuestEnvironment, GuestExternals, GuestFuncIndex, Imports,
 		InstantiationError, Memory, SandboxContext, SandboxInstance,
@@ -153,6 +153,21 @@ impl MemoryTransfer for MemoryWrapper {
 			destination[range].copy_from_slice(source);
 			Ok(())
 		})
+	}
+
+	fn memory_grow(&mut self, pages: u32) -> Result<u32> {
+		self.0
+			.grow(Pages(pages as usize))
+			.map_err(|e| Error::Sandbox(format!("Cannot grow memory in masmi sandbox executor: {}", e)))
+			.map(|p| p.0 as u32)
+	}
+
+	fn memory_size(&mut self) -> u32 {
+		self.0.current_size().0 as u32
+	}
+
+	fn get_buff(&mut self) -> *mut u8 {
+		self.0.direct_access_mut().as_mut().as_mut_ptr()
 	}
 }
 

--- a/client/executor/common/src/util.rs
+++ b/client/executor/common/src/util.rs
@@ -49,4 +49,15 @@ pub trait MemoryTransfer {
 	///
 	/// Returns an error if the write would go out of the memory bounds.
 	fn write_from(&self, dest_addr: Pointer<u8>, source: &[u8]) -> Result<()>;
+
+	/// Grow memory by `pages`.
+	///
+	/// Returns memory prev size.
+	fn memory_grow(&mut self, pages: u32) -> Result<u32>;
+
+	/// Returns memory size in pages.
+	fn memory_size(&mut self) -> u32;
+
+	/// Returns host pointer to the wasm memory buffer.
+	fn get_buff(&mut self) -> *mut u8;
 }

--- a/client/executor/runtime-test/src/lib.rs
+++ b/client/executor/runtime-test/src/lib.rs
@@ -441,6 +441,7 @@ wasm_export_sandbox_test_functions! {
 			Err(sp_sandbox::Error::Module) => 1,
 			Err(sp_sandbox::Error::Execution) => 2,
 			Err(sp_sandbox::Error::OutOfBounds) => 3,
+			Err(sp_sandbox::Error::MemoryGrow) => 4,
 		};
 
 		code

--- a/client/executor/wasmi/src/lib.rs
+++ b/client/executor/wasmi/src/lib.rs
@@ -314,6 +314,33 @@ impl Sandbox for FunctionExecutor {
 			.map(|i| i.get_global_val(name))
 			.map_err(|e| e.to_string())
 	}
+
+	fn memory_grow(&mut self, memory_id: MemoryId, pages: u32) -> WResult<u32> {
+		let mut m = self
+			.sandbox_store
+			.borrow_mut()
+			.memory(memory_id)
+			.map_err(|e| format!("Cannot get wasmi memory: {}", e))?;
+		m.memory_grow(pages).map_err(|e| format!("{}", e))
+	}
+
+	fn memory_size(&mut self, memory_id: MemoryId) -> WResult<u32> {
+		let mut m = self
+			.sandbox_store
+			.borrow_mut()
+			.memory(memory_id)
+			.map_err(|e| format!("Cannot get wasmi memory: {}", e))?;
+		Ok(m.memory_size())
+	}
+
+	fn get_buff(&mut self, memory_id: MemoryId) -> WResult<*mut u8> {
+		let mut m = self
+			.sandbox_store
+			.borrow_mut()
+			.memory(memory_id)
+			.map_err(|e| format!("Cannot get wasmi memory: {}", e))?;
+		Ok(m.get_buff())
+	}
 }
 
 /// Will be used on initialization of a module to resolve function and memory imports.

--- a/client/executor/wasmtime/src/host.rs
+++ b/client/executor/wasmtime/src/host.rs
@@ -30,7 +30,7 @@ use sc_executor_common::{
 	util::MemoryTransfer,
 };
 use sp_sandbox::env as sandbox_env;
-use sp_wasm_interface::{FunctionContext, MemoryId, Pointer, Sandbox, WordSize};
+use sp_wasm_interface::{FunctionContext, MemoryId, Pointer, Result as WResult, Sandbox, WordSize};
 
 use crate::{runtime::StoreData, util};
 
@@ -328,6 +328,26 @@ impl<'a> Sandbox for HostContext<'a> {
 			.instance(instance_idx)
 			.map(|i| i.get_global_val(name))
 			.map_err(|e| e.to_string())
+	}
+
+	fn memory_size(&mut self, memory_id: MemoryId) -> WResult<u32> {
+		let mut m = self
+			.sandbox_store()
+			.memory(memory_id)
+			.map_err(|e| format!("Cannot get wasmer memory: {}", e))?;
+		Ok(m.memory_size())
+	}
+
+	fn memory_grow(&mut self, memory_id: MemoryId, pages_num: u32) -> WResult<u32> {
+		let mut m = self.sandbox_store().memory(memory_id)
+			.map_err(|e| format!("Cannot get wasmer memory: {}", e))?;
+		m.memory_grow(pages_num).map_err(|e| format!("{}", e))
+	}
+
+	fn get_buff(&mut self, memory_id: MemoryId) -> WResult<*mut u8> {
+		let mut m = self.sandbox_store().memory(memory_id)
+			.map_err(|e| format!("Cannot get wasmer memory: {}", e))?;
+		Ok(m.get_buff())
 	}
 }
 

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -491,7 +491,7 @@ where
 			// a trap for now. Eventually, we might want to revisit this.
 			Err(sp_sandbox::Error::Module) => return Err("validation error".into()),
 			// Any other kind of a trap should result in a failure.
-			Err(sp_sandbox::Error::Execution) | Err(sp_sandbox::Error::OutOfBounds) =>
+			Err(sp_sandbox::Error::Execution) | Err(sp_sandbox::Error::OutOfBounds) | Err(sp_sandbox::Error::MemoryGrow) =>
 				return Err(Error::<E::T>::ContractTrapped.into()),
 		}
 	}

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -1655,6 +1655,24 @@ pub trait Sandbox {
 			.get_global_val(instance_idx, name)
 			.expect("Failed to get global from sandbox")
 	}
+
+	fn memory_grow(&mut self, memory_idx: u32, size: u32) -> u32 {
+		self.sandbox()
+			.memory_grow(memory_idx, size)
+			.expect("Failed to grow memory from sandbox")
+	}
+
+	fn memory_size(&mut self, memory_idx: u32) -> u32 {
+		self.sandbox()
+			.memory_size(memory_idx)
+			.expect("Failed to get memory size from sandbox")
+	}
+
+	fn get_buff(&mut self, memory_idx: u32) -> u64 {
+		self.sandbox()
+			.get_buff(memory_idx)
+			.expect("Failed to get wasmo memory buffer addr from sandbox") as u64
+	}
 }
 
 /// Wasm host functions for managing tasks.

--- a/primitives/sandbox/Cargo.toml
+++ b/primitives/sandbox/Cargo.toml
@@ -43,4 +43,4 @@ std = [
 	"wasmi",
 ]
 strict = []
-wasmer-sandbox = []
+host-sandbox = []

--- a/primitives/sandbox/src/embedded_executor.rs
+++ b/primitives/sandbox/src/embedded_executor.rs
@@ -57,12 +57,20 @@ impl super::SandboxMemory for Memory {
 		self.memref.set(ptr, value).map_err(|_| Error::OutOfBounds)?;
 		Ok(())
 	}
-}
 
-impl Memory {
-	/// Returns pointer to the begin of wasm mem buffer
-	pub unsafe fn get_buff(&self) -> *mut u8 {
-		self.memref.direct_access_mut().as_mut().as_mut_ptr()
+	fn grow(&self, pages: u32) -> Result<u32, Error> {
+		self.memref
+			.grow(Pages(pages as usize))
+			.map(|prev| (prev.0 as u32))
+			.map_err(|_| Error::MemoryGrow)
+	}
+
+	fn size(&self) -> u32 {
+		self.memref.current_size().0 as u32
+	}
+
+	unsafe fn get_buff(&self) -> u64 {
+		self.memref.direct_access_mut().as_mut().as_mut_ptr() as usize as u64
 	}
 }
 

--- a/primitives/sandbox/src/embedded_executor.rs
+++ b/primitives/sandbox/src/embedded_executor.rs
@@ -59,6 +59,13 @@ impl super::SandboxMemory for Memory {
 	}
 }
 
+impl Memory {
+	/// Returns pointer to the begin of wasm mem buffer
+	pub unsafe fn get_buff(&self) -> *mut u8 {
+		self.memref.direct_access_mut().as_mut().as_mut_ptr()
+	}
+}
+
 struct HostFuncIndex(usize);
 
 struct DefinedHostFunctions<T> {

--- a/primitives/sandbox/src/host_executor.rs
+++ b/primitives/sandbox/src/host_executor.rs
@@ -100,6 +100,20 @@ impl super::SandboxMemory for Memory {
 			_ => unreachable!(),
 		}
 	}
+
+	fn grow(&self, pages: u32) -> Result<u32, Error> {
+		let size = self.size();
+		sandbox::memory_grow(self.handle.memory_idx, pages);
+		Ok(size)
+	}
+
+	fn size(&self) -> u32 {
+		sandbox::memory_size(self.handle.memory_idx)
+	}
+
+	unsafe fn get_buff(&self) -> u64 {
+		sandbox::get_buff(self.handle.memory_idx)
+	}
 }
 
 /// A builder for the environment of the sandboxed WASM module.

--- a/primitives/wasm-interface/src/lib.rs
+++ b/primitives/wasm-interface/src/lib.rs
@@ -382,6 +382,15 @@ pub trait Sandbox {
 	///
 	/// Returns `Some(_)` when the requested global variable could be found.
 	fn get_global_val(&self, instance_idx: u32, name: &str) -> Result<Option<Value>>;
+
+	/// Returns size in wasm pages of memory with id `memory_id`.
+	fn memory_size(&mut self, memory_id: MemoryId) -> Result<u32>;
+
+	/// Tries to grow memory size by `pages_num`. Returns memory previous size.
+	fn memory_grow(&mut self, memory_id: MemoryId, pages_num: u32) -> Result<u32>;
+
+	/// Get host pointer to the begin of wasm memory with `memory_id`.
+	fn get_buff(&mut self, memory_id: MemoryId) -> Result<*mut u8>;
 }
 
 if_wasmtime_is_enabled! {


### PR DESCRIPTION
- client cli flag to force default execution strategies even if it is dev node
- extend SandboxMemory trait and adjust its implementations