### PR TITLE
Add ability to change globals

### DIFF
--- a/client/executor/common/src/sandbox.rs
+++ b/client/executor/common/src/sandbox.rs
@@ -215,7 +215,7 @@ impl SandboxInstance {
 
 	/// Set the value of a global with the given `name`.
 	///
-	/// Returns `Ok(())` if the global could be modified.
+	/// Returns `Ok(Some(()))` if the global could be modified.
 	pub fn set_global_val(&self, name: &str, value: sp_wasm_interface::Value) -> std::result::Result<Option<()>, error::Error> {
 		match &self.backend_instance {
 			BackendInstance::Wasmi(wasmi_instance) => wasmi_set_global(wasmi_instance, name, value),

--- a/client/executor/common/src/sandbox.rs
+++ b/client/executor/common/src/sandbox.rs
@@ -37,12 +37,12 @@ use crate::{
 
 #[cfg(feature = "wasmer-sandbox")]
 use self::wasmer_backend::{
-	get_global as wasmer_get_global, instantiate as wasmer_instantiate, invoke as wasmer_invoke,
+	get_global as wasmer_get_global, set_global as wasmer_set_global, instantiate as wasmer_instantiate, invoke as wasmer_invoke,
 	new_memory as wasmer_new_memory, Backend as WasmerBackend,
 	MemoryWrapper as WasmerMemoryWrapper,
 };
 use self::wasmi_backend::{
-	get_global as wasmi_get_global, instantiate as wasmi_instantiate, invoke as wasmi_invoke,
+	get_global as wasmi_get_global, set_global as wasmi_set_global, instantiate as wasmi_instantiate, invoke as wasmi_invoke,
 	new_memory as wasmi_new_memory, MemoryWrapper as WasmiMemoryWrapper,
 };
 
@@ -210,6 +210,18 @@ impl SandboxInstance {
 
 			#[cfg(feature = "wasmer-sandbox")]
 			BackendInstance::Wasmer(wasmer_instance) => wasmer_get_global(wasmer_instance, name),
+		}
+	}
+
+	/// Set the value of a global with the given `name`.
+	///
+	/// Returns `Ok(())` if the global could be modified.
+	pub fn set_global_val(&self, name: &str, value: sp_wasm_interface::Value) -> std::result::Result<Option<()>, error::Error> {
+		match &self.backend_instance {
+			BackendInstance::Wasmi(wasmi_instance) => wasmi_set_global(wasmi_instance, name, value),
+
+			#[cfg(feature = "wasmer-sandbox")]
+			BackendInstance::Wasmer(wasmer_instance) => wasmer_set_global(wasmer_instance, name, value),
 		}
 	}
 }

--- a/client/executor/common/src/sandbox/wasmer_backend.rs
+++ b/client/executor/common/src/sandbox/wasmer_backend.rs
@@ -521,3 +521,20 @@ pub fn get_global(instance: &wasmer::Instance, name: &str) -> Option<Value> {
 
 	Some(wasmtime_value)
 }
+
+/// Set global value by name
+pub fn set_global(instance: &wasmer::Instance, name: &str, value: Value) -> core::result::Result<Option<()>, crate::error::Error> {
+	let global = match instance.exports.get_global(name) {
+		Ok(g) => g,
+		Err(_) => return Ok(None),
+	};
+
+	let value = match value {
+		Value::I32(val) => wasmer::Val::I32(val),
+		Value::I64(val) => wasmer::Val::I64(val),
+		Value::F32(val) => wasmer::Val::F32(f32::from_bits(val)),
+		Value::F64(val) => wasmer::Val::F64(f64::from_bits(val)),
+	};
+
+	global.set(value).map(|_| Some(())).map_err(|e| crate::error::Error::Sandbox(e.message()))
+}

--- a/client/executor/common/src/sandbox/wasmi_backend.rs
+++ b/client/executor/common/src/sandbox/wasmi_backend.rs
@@ -347,3 +347,21 @@ pub fn invoke(
 pub fn get_global(instance: &wasmi::ModuleRef, name: &str) -> Option<Value> {
 	Some(instance.export_by_name(name)?.as_global()?.get().into())
 }
+
+/// Set global value by name
+pub fn set_global(instance: &wasmi::ModuleRef, name: &str, value: Value) -> std::result::Result<Option<()>, error::Error> {
+	let export = match instance.export_by_name(name) {
+		Some(e) => e,
+		None => return Ok(None),
+	};
+
+	let global = match export.as_global() {
+		Some(g) => g,
+		None => return Ok(None),
+	};
+
+	global
+		.set(value.into())
+		.map(|_| Some(()))
+		.map_err(error::Error::Wasmi)
+}

--- a/client/executor/wasmi/src/lib.rs
+++ b/client/executor/wasmi/src/lib.rs
@@ -316,6 +316,24 @@ impl Sandbox for FunctionExecutor {
 			.map_err(|e| e.to_string())
 	}
 
+	fn set_global_val(&self, instance_idx: u32, name: &str, value: sp_wasm_interface::Value) -> WResult<u32> {
+		trace!(target: "sp-sandbox", "set_global_val, instance_idx={}", instance_idx);
+
+		let instance = self.sandbox_store
+			.borrow()
+			.instance(instance_idx)
+			.map_err(|e| e.to_string())?;
+
+		let result = instance.set_global_val(name, value);
+
+		trace!(target: "sp-sandbox", "set_global_val, name={name}, value={value:?}, result={result:?}");
+		match result {
+			Ok(None) => Ok(sandbox_env::ERROR_GLOBALS_NOT_FOUND),
+			Ok(Some(_)) => Ok(sandbox_env::ERROR_GLOBALS_OK),
+			Err(_) => Ok(sandbox_env::ERROR_GLOBALS_OTHER),
+		}
+	}
+
 	fn memory_grow(&mut self, memory_id: MemoryId, pages: u32) -> WResult<u32> {
 		let mut m = self
 			.sandbox_store

--- a/client/executor/wasmtime/src/host.rs
+++ b/client/executor/wasmtime/src/host.rs
@@ -331,6 +331,23 @@ impl<'a> Sandbox for HostContext<'a> {
 			.map_err(|e| e.to_string())
 	}
 
+	fn set_global_val(&self, instance_idx: u32, name: &str, value: sp_wasm_interface::Value) -> sp_wasm_interface::Result<u32> {
+		trace!(target: "sp-sandbox", "set_global_val, instance_idx={}", instance_idx);
+
+		let instance = self.sandbox_store()
+			.instance(instance_idx)
+			.map_err(|e| e.to_string())?;
+
+		let result = instance.set_global_val(name, value);
+
+		trace!(target: "sp-sandbox", "set_global_val, name={name}, value={value:?}, result={result:?}");
+		match result {
+			Ok(None) => Ok(sandbox_env::ERROR_GLOBALS_NOT_FOUND),
+			Ok(Some(_)) => Ok(sandbox_env::ERROR_GLOBALS_OK),
+			Err(_) => Ok(sandbox_env::ERROR_GLOBALS_OTHER),
+		}
+	}
+
 	fn memory_size(&mut self, memory_id: MemoryId) -> sp_wasm_interface::Result<u32> {
 		let mut m = self
 			.sandbox_store()

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -1656,6 +1656,19 @@ pub trait Sandbox {
 			.expect("Failed to get global from sandbox")
 	}
 
+	/// Set the value of a global with the given `name`. The sandbox is determined by the given
+	/// `instance_idx`.
+	fn set_global_val(
+		&mut self,
+		instance_idx: u32,
+		name: &str,
+		value: sp_wasm_interface::Value,
+	) -> u32 {
+		self.sandbox()
+			.set_global_val(instance_idx, name, value)
+			.expect("Failed to set global in sandbox")
+	}
+
 	fn memory_grow(&mut self, memory_idx: u32, size: u32) -> u32 {
 		self.sandbox()
 			.memory_grow(memory_idx, size)

--- a/primitives/sandbox/src/embedded_executor.rs
+++ b/primitives/sandbox/src/embedded_executor.rs
@@ -251,9 +251,24 @@ pub struct Instance<T> {
 	_marker: PhantomData<T>,
 }
 
+/// Unit-type as InstanceGlobals for wasmi executor.
+#[derive(Clone, Default)]
+pub struct InstanceGlobals;
+
+impl super::InstanceGlobals for InstanceGlobals {
+	fn get_global_val(&self, _name: &str) -> Option<Value> {
+		None
+	}
+
+	fn set_global_val(&self, _name: &str, _value: Value) -> Result<(), super::GlobalsSetError> {
+		Err(super::GlobalsSetError::NotFound)
+	}
+}
+
 impl<T> super::SandboxInstance<T> for Instance<T> {
 	type Memory = Memory;
 	type EnvironmentBuilder = EnvironmentDefinitionBuilder<T>;
+	type InstanceGlobals = InstanceGlobals;
 
 	fn new(
 		code: &[u8],
@@ -294,6 +309,10 @@ impl<T> super::SandboxInstance<T> for Instance<T> {
 		let global = self.instance.export_by_name(name)?.as_global()?.get();
 
 		Some(to_interface(global))
+	}
+
+	fn instance_globals(&self) -> Option<Self::InstanceGlobals> {
+		None
 	}
 }
 

--- a/primitives/sandbox/src/env.rs
+++ b/primitives/sandbox/src/env.rs
@@ -86,6 +86,21 @@ pub const ERR_OUT_OF_BOUNDS: u32 = -2i32 as u32;
 /// For FFI purposes.
 pub const ERR_EXECUTION: u32 = -3i32 as u32;
 
+/// A global variable has been sucessfully changed.
+///
+/// For FFI purposes.
+pub const ERROR_GLOBALS_OK: u32 = 0;
+
+/// A global variable is not found.
+///
+/// For FFI purposes.
+pub const ERROR_GLOBALS_NOT_FOUND: u32 = u32::MAX;
+
+/// A global variable is immutable or has a different type.
+///
+/// For FFI purposes.
+pub const ERROR_GLOBALS_OTHER: u32 = u32::MAX - 1;
+
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/primitives/sandbox/src/lib.rs
+++ b/primitives/sandbox/src/lib.rs
@@ -224,7 +224,7 @@ pub enum GlobalsSetError {
 }
 
 /// This instance can be used for changing exported globals.
-pub trait InstanceGlobals: Sized + Clone + Default {
+pub trait InstanceGlobals: Sized + Clone {
 
 	/// Get the value from a global with the given `name`.
 	///

--- a/primitives/sandbox/src/lib.rs
+++ b/primitives/sandbox/src/lib.rs
@@ -167,6 +167,9 @@ pub trait SandboxInstance<State>: Sized {
 	/// The environment builder used to construct this sandbox.
 	type EnvironmentBuilder: SandboxEnvironmentBuilder<State, Self::Memory>;
 
+	/// The globals type used for this sandbox to change globals.
+	type InstanceGlobals: InstanceGlobals;
+
 	/// Instantiate a module with the given [`EnvironmentDefinitionBuilder`]. It will
 	/// run the `start` function (if it is present in the module) with the given `state`.
 	///
@@ -203,4 +206,31 @@ pub trait SandboxInstance<State>: Sized {
 	///
 	/// Returns `Some(_)` if the global could be found.
 	fn get_global_val(&self, name: &str) -> Option<Value>;
+
+	/// Get the instance providing access to exported globals.
+	///
+	/// Returns `None` if the executor doesn't support the interface.
+	fn instance_globals(&self) -> Option<Self::InstanceGlobals>;
 }
+
+/// Error that can occur while using this crate.
+#[derive(RuntimeDebug)]
+pub enum GlobalsSetError {
+	/// A global variable is not found.
+	NotFound,
+
+	/// A global variable is immutable or has a different type.
+	Other,
+}
+
+/// This instance can be used for changing exported globals.
+pub trait InstanceGlobals: Sized + Clone + Default {
+
+	/// Get the value from a global with the given `name`.
+	///
+	/// Returns `Some(_)` if the global could be found.
+	fn get_global_val(&self, name: &str) -> Option<Value>;
+
+	/// Set the value of a global with the given `name`.
+	fn set_global_val(&self, name: &str, value: Value) -> Result<(), GlobalsSetError>;
+ }

--- a/primitives/wasm-interface/src/lib.rs
+++ b/primitives/wasm-interface/src/lib.rs
@@ -383,6 +383,12 @@ pub trait Sandbox {
 	/// Returns `Some(_)` when the requested global variable could be found.
 	fn get_global_val(&self, instance_idx: u32, name: &str) -> Result<Option<Value>>;
 
+	/// Set the value of a global with the given `name`. The sandbox is determined by the
+	/// given `instance_idx` instance.
+	///
+	/// Returns `Ok(())` when the requested global variable could be modified.
+	fn set_global_val(&self, instance_idx: u32, name: &str, value: Value) -> Result<u32>;
+
 	/// Returns size in wasm pages of memory with id `memory_id`.
 	fn memory_size(&mut self, memory_id: MemoryId) -> Result<u32>;
 


### PR DESCRIPTION
https://github.com/gear-tech/gear/issues/1606

- introduce new trait/type `InstanceGlobals` with get/set methods
- add `Sandbox::instance_globalas` method to return Option with an instance. Returns None for embedded executor since it doesn't required to support this feature