### PR TITLE
add get instance ptr

### DIFF
--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -31,6 +31,8 @@
 
 use sp_std::vec::Vec;
 
+use sp_wasm_interface::HostPointer;
+
 #[cfg(feature = "std")]
 use tracing;
 
@@ -1681,10 +1683,14 @@ pub trait Sandbox {
 			.expect("Failed to get memory size from sandbox")
 	}
 
-	fn get_buff(&mut self, memory_idx: u32) -> u64 {
+	fn get_buff(&mut self, memory_idx: u32) -> HostPointer {
 		self.sandbox()
 			.get_buff(memory_idx)
-			.expect("Failed to get wasmo memory buffer addr from sandbox") as u64
+			.expect("Failed to get wasm memory buffer addr from sandbox")
+	}
+
+	fn get_instance_ptr(&mut self, instance_id: u32) -> HostPointer {
+		self.sandbox().get_instance_ptr(instance_id).expect("Failed to get instance ptr")
 	}
 }
 

--- a/primitives/sandbox/src/embedded_executor.rs
+++ b/primitives/sandbox/src/embedded_executor.rs
@@ -19,6 +19,7 @@
 
 use alloc::string::String;
 
+use sp_wasm_interface::HostPointer;
 use wasmi::{
 	memory_units::Pages, Externals, FuncInstance, FuncRef, GlobalDescriptor, GlobalRef,
 	ImportResolver, MemoryDescriptor, MemoryInstance, MemoryRef, Module, ModuleInstance, ModuleRef,
@@ -313,6 +314,10 @@ impl<T> super::SandboxInstance<T> for Instance<T> {
 
 	fn instance_globals(&self) -> Option<Self::InstanceGlobals> {
 		None
+	}
+
+	fn get_instance_ptr(&self) -> HostPointer {
+		unreachable!("Must not be called for embedded executor")
 	}
 }
 

--- a/primitives/sandbox/src/host_executor.rs
+++ b/primitives/sandbox/src/host_executor.rs
@@ -21,6 +21,7 @@ use codec::{Decode, Encode};
 
 use sp_io::sandbox;
 use sp_std::{marker, mem, prelude::*, rc::Rc, slice, vec};
+use sp_wasm_interface::HostPointer;
 
 use crate::{env, Error, HostFuncType, ReturnValue, Value};
 
@@ -111,7 +112,7 @@ impl super::SandboxMemory for Memory {
 		sandbox::memory_size(self.handle.memory_idx)
 	}
 
-	unsafe fn get_buff(&self) -> u64 {
+	unsafe fn get_buff(&self) -> HostPointer {
 		sandbox::get_buff(self.handle.memory_idx)
 	}
 }
@@ -305,6 +306,10 @@ impl<T> super::SandboxInstance<T> for Instance<T> {
 
 	fn instance_globals(&self) -> Option<Self::InstanceGlobals> {
 		Some(InstanceGlobals { instance_idx: Some(self.instance_idx) })
+	}
+
+	fn get_instance_ptr(&self) -> HostPointer {
+		sandbox::get_instance_ptr(self.instance_idx)
 	}
 }
 

--- a/primitives/sandbox/src/lib.rs
+++ b/primitives/sandbox/src/lib.rs
@@ -48,6 +48,7 @@ pub mod host_executor;
 use sp_core::RuntimeDebug;
 use sp_std::prelude::*;
 
+use sp_wasm_interface::HostPointer;
 pub use sp_wasm_interface::{ReturnValue, Value};
 
 #[cfg(not(all(feature = "host-sandbox", not(feature = "std"))))]
@@ -119,7 +120,7 @@ pub trait SandboxMemory: Sized + Clone {
 
 	/// Grow memory with provided number of pages.
 	///
-	/// Returns `Err` if attempted to allocate more memory than permited by the limit.
+	/// Returns `Err` if attempted to allocate more memory than permitted by the limit.
 	fn grow(&self, pages: u32) -> Result<u32, Error>;
 
 	/// Returns current memory size.
@@ -128,7 +129,7 @@ pub trait SandboxMemory: Sized + Clone {
 	fn size(&self) -> u32;
 
 	/// Returns pointer to the begin of wasm mem buffer
-	unsafe fn get_buff(&self) -> u64;
+	unsafe fn get_buff(&self) -> HostPointer;
 }
 
 /// Struct that can be used for defining an environment for a sandboxed module.
@@ -211,6 +212,9 @@ pub trait SandboxInstance<State>: Sized {
 	///
 	/// Returns `None` if the executor doesn't support the interface.
 	fn instance_globals(&self) -> Option<Self::InstanceGlobals>;
+
+	/// Get raw pointer to the executor host sandbox instance.
+	fn get_instance_ptr(&self) -> HostPointer;
 }
 
 /// Error that can occur while using this crate.

--- a/primitives/wasm-interface/src/lib.rs
+++ b/primitives/wasm-interface/src/lib.rs
@@ -333,6 +333,9 @@ pub trait FunctionContext {
 /// Sandbox memory identifier.
 pub type MemoryId = u32;
 
+/// Host pointer: suit both for 32-bit and 64-bit archs.
+pub type HostPointer = u64;
+
 /// Something that provides access to the sandbox.
 pub trait Sandbox {
 	/// Get sandbox memory from the `memory_id` instance at `offset` into the given buffer.
@@ -396,7 +399,12 @@ pub trait Sandbox {
 	fn memory_grow(&mut self, memory_id: MemoryId, pages_num: u32) -> Result<u32>;
 
 	/// Get host pointer to the begin of wasm memory with `memory_id`.
-	fn get_buff(&mut self, memory_id: MemoryId) -> Result<*mut u8>;
+	fn get_buff(&mut self, memory_id: MemoryId) -> Result<HostPointer>;
+
+	/// Get raw pointer to the executor host sandbox instance.
+	///
+	/// Returns Err if instance is not exist for `instance_id`.
+	fn get_instance_ptr(&mut self, instance_id: u32) -> Result<HostPointer>;
 }
 
 if_wasmtime_is_enabled! {

--- a/primitives/wasm-interface/src/lib.rs
+++ b/primitives/wasm-interface/src/lib.rs
@@ -403,7 +403,7 @@ pub trait Sandbox {
 
 	/// Get raw pointer to the executor host sandbox instance.
 	///
-	/// Returns Err if instance is not exist for `instance_id`.
+	/// Returns Err if the instance `instance_id` does not exist.
 	fn get_instance_ptr(&mut self, instance_id: u32) -> Result<HostPointer>;
 }
 


### PR DESCRIPTION
implement new sandbox runtime-interface function: `get_instance_ptr`, which returns raw host pointer to the sandbox instance in order to use it inside lazy-pages to access globals from signal-handler.

Tested with: `cargo test --workspace --release`