### PR TITLE
refactor(sandbox,executor): set global primitive type

### DIFF
--- a/client/executor/common/src/sandbox.rs
+++ b/client/executor/common/src/sandbox.rs
@@ -37,13 +37,14 @@ use crate::{
 
 #[cfg(feature = "host-sandbox")]
 use self::wasmer_backend::{
-	get_global as wasmer_get_global, set_global as wasmer_set_global, instantiate as wasmer_instantiate, invoke as wasmer_invoke,
-	new_memory as wasmer_new_memory, Backend as WasmerBackend,
-	MemoryWrapper as WasmerMemoryWrapper,
+	get_global as wasmer_get_global, instantiate as wasmer_instantiate, invoke as wasmer_invoke,
+	new_memory as wasmer_new_memory, set_global_i64 as wasmer_set_global_i64,
+	Backend as WasmerBackend, MemoryWrapper as WasmerMemoryWrapper,
 };
 use self::wasmi_backend::{
-	get_global as wasmi_get_global, set_global as wasmi_set_global, instantiate as wasmi_instantiate, invoke as wasmi_invoke,
-	new_memory as wasmi_new_memory, MemoryWrapper as WasmiMemoryWrapper,
+	get_global as wasmi_get_global, instantiate as wasmi_instantiate, invoke as wasmi_invoke,
+	new_memory as wasmi_new_memory, set_global as wasmi_set_global,
+	MemoryWrapper as WasmiMemoryWrapper,
 };
 
 /// Index of a function inside the supervisor.
@@ -227,7 +228,7 @@ impl SandboxInstance {
 			},
 
 			#[cfg(feature = "host-sandbox")]
-			BackendInstance::Wasmer(wasmer_instance) => wasmer_set_global(wasmer_instance, name, value),
+			BackendInstance::Wasmer(wasmer_instance) => wasmer_set_global_i64(wasmer_instance, name, value),
 		}
 	}
 }

--- a/client/executor/common/src/sandbox.rs
+++ b/client/executor/common/src/sandbox.rs
@@ -216,9 +216,15 @@ impl SandboxInstance {
 	/// Set the value of a global with the given `name`.
 	///
 	/// Returns `Ok(Some(()))` if the global could be modified.
-	pub fn set_global_val(&self, name: &str, value: sp_wasm_interface::Value) -> std::result::Result<Option<()>, error::Error> {
+	pub fn set_global_i64(
+		&self,
+		name: &str,
+		value: i64,
+	) -> std::result::Result<Option<()>, error::Error> {
 		match &self.backend_instance {
-			BackendInstance::Wasmi(wasmi_instance) => wasmi_set_global(wasmi_instance, name, value),
+			BackendInstance::Wasmi(wasmi_instance) => {
+				wasmi_set_global(wasmi_instance, name, sp_wasm_interface::Value::I64(value))
+			},
 
 			#[cfg(feature = "host-sandbox")]
 			BackendInstance::Wasmer(wasmer_instance) => wasmer_set_global(wasmer_instance, name, value),

--- a/client/executor/common/src/sandbox/wasmer_backend.rs
+++ b/client/executor/common/src/sandbox/wasmer_backend.rs
@@ -533,18 +533,18 @@ pub fn get_global(instance: &wasmer::Instance, name: &str) -> Option<Value> {
 }
 
 /// Set global value by name
-pub fn set_global(instance: &wasmer::Instance, name: &str, value: Value) -> core::result::Result<Option<()>, crate::error::Error> {
+pub fn set_global(
+	instance: &wasmer::Instance,
+	name: &str,
+	value: i64,
+) -> core::result::Result<Option<()>, crate::error::Error> {
 	let global = match instance.exports.get_global(name) {
 		Ok(g) => g,
 		Err(_) => return Ok(None),
 	};
 
-	let value = match value {
-		Value::I32(val) => wasmer::Val::I32(val),
-		Value::I64(val) => wasmer::Val::I64(val),
-		Value::F32(val) => wasmer::Val::F32(f32::from_bits(val)),
-		Value::F64(val) => wasmer::Val::F64(f64::from_bits(val)),
-	};
-
-	global.set(value).map(|_| Some(())).map_err(|e| crate::error::Error::Sandbox(e.message()))
+	global
+		.set(wasmer::Val::I64(value))
+		.map(|_| Some(()))
+		.map_err(|e| crate::error::Error::Sandbox(e.message()))
 }

--- a/client/executor/common/src/sandbox/wasmer_backend.rs
+++ b/client/executor/common/src/sandbox/wasmer_backend.rs
@@ -533,7 +533,7 @@ pub fn get_global(instance: &wasmer::Instance, name: &str) -> Option<Value> {
 }
 
 /// Set global value by name
-pub fn set_global(
+pub fn set_global_i64(
 	instance: &wasmer::Instance,
 	name: &str,
 	value: i64,

--- a/client/executor/common/src/sandbox/wasmi_backend.rs
+++ b/client/executor/common/src/sandbox/wasmi_backend.rs
@@ -349,7 +349,11 @@ pub fn get_global(instance: &wasmi::ModuleRef, name: &str) -> Option<Value> {
 }
 
 /// Set global value by name
-pub fn set_global(instance: &wasmi::ModuleRef, name: &str, value: Value) -> std::result::Result<Option<()>, error::Error> {
+pub fn set_global(
+	instance: &wasmi::ModuleRef,
+	name: &str,
+	value: Value,
+) -> std::result::Result<Option<()>, error::Error> {
 	let export = match instance.export_by_name(name) {
 		Some(e) => e,
 		None => return Ok(None),
@@ -360,8 +364,5 @@ pub fn set_global(instance: &wasmi::ModuleRef, name: &str, value: Value) -> std:
 		None => return Ok(None),
 	};
 
-	global
-		.set(value.into())
-		.map(|_| Some(()))
-		.map_err(error::Error::Wasmi)
+	global.set(value.into()).map(|_| Some(())).map_err(error::Error::Wasmi)
 }

--- a/client/executor/wasmi/src/lib.rs
+++ b/client/executor/wasmi/src/lib.rs
@@ -353,17 +353,15 @@ impl Sandbox for FunctionExecutor {
 			.map_err(|e| e.to_string())
 	}
 
-	fn set_global_val(&self, instance_idx: u32, name: &str, value: sp_wasm_interface::Value) -> WResult<u32> {
-		trace!(target: "sp-sandbox", "set_global_val, instance_idx={}", instance_idx);
+	fn set_global_i64(&self, instance_idx: u32, name: &str, value: i64) -> WResult<u32> {
+		trace!(target: "sp-sandbox", "set_global_i64, instance_idx={}", instance_idx);
 
-		let instance = self.sandbox_store
-			.borrow()
-			.instance(instance_idx)
-			.map_err(|e| e.to_string())?;
+		let instance =
+			self.sandbox_store.borrow().instance(instance_idx).map_err(|e| e.to_string())?;
 
-		let result = instance.set_global_val(name, value);
+		let result = instance.set_global_i64(name, value);
 
-		trace!(target: "sp-sandbox", "set_global_val, name={name}, value={value:?}, result={result:?}");
+		trace!(target: "sp-sandbox", "set_global_i64, name={name}, value={value:?}, result={result:?}");
 		match result {
 			Ok(None) => Ok(sandbox_env::ERROR_GLOBALS_NOT_FOUND),
 			Ok(Some(_)) => Ok(sandbox_env::ERROR_GLOBALS_OK),

--- a/client/executor/wasmtime/src/host.rs
+++ b/client/executor/wasmtime/src/host.rs
@@ -358,16 +358,19 @@ impl<'a> Sandbox for HostContext<'a> {
 			.map_err(|e| e.to_string())
 	}
 
-	fn set_global_val(&self, instance_idx: u32, name: &str, value: sp_wasm_interface::Value) -> sp_wasm_interface::Result<u32> {
-		trace!(target: "sp-sandbox", "set_global_val, instance_idx={}", instance_idx);
+	fn set_global_i64(
+		&self,
+		instance_idx: u32,
+		name: &str,
+		value: i64,
+	) -> sp_wasm_interface::Result<u32> {
+		trace!(target: "sp-sandbox", "set_global_i64, instance_idx={}", instance_idx);
 
-		let instance = self.sandbox_store()
-			.instance(instance_idx)
-			.map_err(|e| e.to_string())?;
+		let instance = self.sandbox_store().instance(instance_idx).map_err(|e| e.to_string())?;
 
-		let result = instance.set_global_val(name, value);
+		let result = instance.set_global_i64(name, value);
 
-		trace!(target: "sp-sandbox", "set_global_val, name={name}, value={value:?}, result={result:?}");
+		trace!(target: "sp-sandbox", "set_global_i64, name={name}, value={value:?}, result={result:?}");
 		match result {
 			Ok(None) => Ok(sandbox_env::ERROR_GLOBALS_NOT_FOUND),
 			Ok(Some(_)) => Ok(sandbox_env::ERROR_GLOBALS_OK),

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -1710,14 +1710,9 @@ pub trait Sandbox {
 
 	/// Set the value of a global with the given `name`. The sandbox is determined by the given
 	/// `instance_idx`.
-	fn set_global_val(
-		&mut self,
-		instance_idx: u32,
-		name: &str,
-		value: sp_wasm_interface::Value,
-	) -> u32 {
+	fn set_global_i64(&mut self, instance_idx: u32, name: &str, value: i64) -> u32 {
 		self.sandbox()
-			.set_global_val(instance_idx, name, value)
+			.set_global_i64(instance_idx, name, value)
 			.expect("Failed to set global in sandbox")
 	}
 

--- a/primitives/sandbox/src/embedded_executor.rs
+++ b/primitives/sandbox/src/embedded_executor.rs
@@ -261,7 +261,7 @@ impl super::InstanceGlobals for InstanceGlobals {
 		None
 	}
 
-	fn set_global_val(&self, _name: &str, _value: Value) -> Result<(), super::GlobalsSetError> {
+	fn set_global_i64(&self, _name: &str, _value: i64) -> Result<(), super::GlobalsSetError> {
 		Err(super::GlobalsSetError::NotFound)
 	}
 }

--- a/primitives/sandbox/src/host_executor.rs
+++ b/primitives/sandbox/src/host_executor.rs
@@ -187,14 +187,14 @@ impl super::InstanceGlobals for InstanceGlobals {
 		self.instance_idx.and_then(|i| sandbox::get_global_val(i, name))
 	}
 
-	fn set_global_val(&self, name: &str, value: Value) -> Result<(), super::GlobalsSetError> {
+	fn set_global_i64(&self, name: &str, value: i64) -> Result<(), super::GlobalsSetError> {
 		match self.instance_idx {
 			None => Err(super::GlobalsSetError::Other),
-			Some(i) => match sandbox::set_global_val(i, name, value) {
+			Some(i) => match sandbox::set_global_i64(i, name, value) {
 				env::ERROR_GLOBALS_OK => Ok(()),
 				env::ERROR_GLOBALS_NOT_FOUND => Err(super::GlobalsSetError::NotFound),
 				_ => Err(super::GlobalsSetError::Other),
-			}
+			},
 		}
 	}
 }

--- a/primitives/sandbox/src/lib.rs
+++ b/primitives/sandbox/src/lib.rs
@@ -229,12 +229,11 @@ pub enum GlobalsSetError {
 
 /// This instance can be used for changing exported globals.
 pub trait InstanceGlobals: Sized + Clone {
-
 	/// Get the value from a global with the given `name`.
 	///
 	/// Returns `Some(_)` if the global could be found.
 	fn get_global_val(&self, name: &str) -> Option<Value>;
 
 	/// Set the value of a global with the given `name`.
-	fn set_global_val(&self, name: &str, value: Value) -> Result<(), GlobalsSetError>;
- }
+	fn set_global_i64(&self, name: &str, value: i64) -> Result<(), GlobalsSetError>;
+}

--- a/primitives/wasm-interface/src/lib.rs
+++ b/primitives/wasm-interface/src/lib.rs
@@ -393,7 +393,7 @@ pub trait Sandbox {
 	/// given `instance_idx` instance.
 	///
 	/// Returns `Ok(())` when the requested global variable could be modified.
-	fn set_global_val(&self, instance_idx: u32, name: &str, value: Value) -> Result<u32>;
+	fn set_global_i64(&self, instance_idx: u32, name: &str, value: i64) -> Result<u32>;
 
 	/// Returns size in wasm pages of memory with id `memory_id`.
 	fn memory_size(&mut self, memory_id: MemoryId) -> Result<u32>;


### PR DESCRIPTION
This avoids encoding the `Value` in the runtime interface with the SCALE codec, which drastically reduces performance.

We use only i64 for now.

See https://paritytech.github.io/substrate/master/sp_runtime_interface/index.html