### PR TITLE
refactor(sandbox): return global as primitive

### DIFF
--- a/client/executor/common/src/sandbox.rs
+++ b/client/executor/common/src/sandbox.rs
@@ -37,13 +37,16 @@ use crate::{
 
 #[cfg(feature = "host-sandbox")]
 use self::wasmer_backend::{
-	get_global as wasmer_get_global, instantiate as wasmer_instantiate, invoke as wasmer_invoke,
-	new_memory as wasmer_new_memory, set_global_i64 as wasmer_set_global_i64,
-	Backend as WasmerBackend, MemoryWrapper as WasmerMemoryWrapper,
+	get_global as wasmer_get_global, get_global_i32 as wasmer_get_global_i32,
+	get_global_i64 as wasmer_get_global_i64, instantiate as wasmer_instantiate,
+	invoke as wasmer_invoke, new_memory as wasmer_new_memory,
+	set_global_i64 as wasmer_set_global_i64, Backend as WasmerBackend,
+	MemoryWrapper as WasmerMemoryWrapper,
 };
 use self::wasmi_backend::{
-	get_global as wasmi_get_global, instantiate as wasmi_instantiate, invoke as wasmi_invoke,
-	new_memory as wasmi_new_memory, set_global as wasmi_set_global,
+	get_global as wasmi_get_global, get_global_i32 as wasmi_get_global_i32,
+	get_global_i64 as wasmi_get_global_i64, instantiate as wasmi_instantiate,
+	invoke as wasmi_invoke, new_memory as wasmi_new_memory, set_global as wasmi_set_global,
 	MemoryWrapper as WasmiMemoryWrapper,
 };
 
@@ -211,6 +214,24 @@ impl SandboxInstance {
 
 			#[cfg(feature = "host-sandbox")]
 			BackendInstance::Wasmer(wasmer_instance) => wasmer_get_global(wasmer_instance, name),
+		}
+	}
+
+	pub fn get_global_i32(&self, name: &str) -> Option<i32> {
+		match &self.backend_instance {
+			BackendInstance::Wasmi(wasmi_instance) => wasmi_get_global_i32(wasmi_instance, name),
+
+			#[cfg(feature = "host-sandbox")]
+			BackendInstance::Wasmer(wasmer_instance) => wasmer_get_global_i32(wasmer_instance, name),
+		}
+	}
+
+	pub fn get_global_i64(&self, name: &str) -> Option<i64> {
+		match &self.backend_instance {
+			BackendInstance::Wasmi(wasmi_instance) => wasmi_get_global_i64(wasmi_instance, name),
+
+			#[cfg(feature = "host-sandbox")]
+			BackendInstance::Wasmer(wasmer_instance) => wasmer_get_global_i64(wasmer_instance, name),
 		}
 	}
 

--- a/client/executor/common/src/sandbox/wasmer_backend.rs
+++ b/client/executor/common/src/sandbox/wasmer_backend.rs
@@ -532,6 +532,18 @@ pub fn get_global(instance: &wasmer::Instance, name: &str) -> Option<Value> {
 	Some(wasmtime_value)
 }
 
+pub fn get_global_i32(instance: &wasmer::Instance, name: &str) -> Option<i32> {
+	let global = instance.exports.get_global(name).ok()?;
+
+	global.get().i32()
+}
+
+pub fn get_global_i64(instance: &wasmer::Instance, name: &str) -> Option<i64> {
+	let global = instance.exports.get_global(name).ok()?;
+
+	global.get().i64()
+}
+
 /// Set global value by name
 pub fn set_global_i64(
 	instance: &wasmer::Instance,

--- a/client/executor/common/src/sandbox/wasmer_backend.rs
+++ b/client/executor/common/src/sandbox/wasmer_backend.rs
@@ -545,6 +545,30 @@ pub fn get_global_i64(instance: &wasmer::Instance, name: &str) -> Option<i64> {
 }
 
 /// Set global value by name
+pub fn set_global(
+	instance: &wasmer::Instance,
+	name: &str,
+	value: Value,
+) -> core::result::Result<Option<()>, crate::error::Error> {
+	let global = match instance.exports.get_global(name) {
+		Ok(g) => g,
+		Err(_) => return Ok(None),
+	};
+
+	let value = match value {
+		Value::I32(val) => wasmer::Val::I32(val),
+		Value::I64(val) => wasmer::Val::I64(val),
+		Value::F32(val) => wasmer::Val::F32(f32::from_bits(val)),
+		Value::F64(val) => wasmer::Val::F64(f64::from_bits(val)),
+	};
+
+	global
+		.set(value)
+		.map(|_| Some(()))
+		.map_err(|e| crate::error::Error::Sandbox(e.message()))
+}
+
+/// Set global i64 by name
 pub fn set_global_i64(
 	instance: &wasmer::Instance,
 	name: &str,

--- a/client/executor/common/src/sandbox/wasmi_backend.rs
+++ b/client/executor/common/src/sandbox/wasmi_backend.rs
@@ -348,6 +348,14 @@ pub fn get_global(instance: &wasmi::ModuleRef, name: &str) -> Option<Value> {
 	Some(instance.export_by_name(name)?.as_global()?.get().into())
 }
 
+pub fn get_global_i32(instance: &wasmi::ModuleRef, name: &str) -> Option<i32> {
+	instance.export_by_name(name)?.as_global()?.get().try_into()
+}
+
+pub fn get_global_i64(instance: &wasmi::ModuleRef, name: &str) -> Option<i64> {
+	instance.export_by_name(name)?.as_global()?.get().try_into()
+}
+
 /// Set global value by name
 pub fn set_global(
 	instance: &wasmi::ModuleRef,

--- a/client/executor/wasmi/src/lib.rs
+++ b/client/executor/wasmi/src/lib.rs
@@ -353,6 +353,22 @@ impl Sandbox for FunctionExecutor {
 			.map_err(|e| e.to_string())
 	}
 
+	fn get_global_i32(&self, instance_idx: u32, name: &str) -> WResult<Option<i32>> {
+		self.sandbox_store
+			.borrow()
+			.instance(instance_idx)
+			.map(|i| i.get_global_i32(name))
+			.map_err(|e| e.to_string())
+	}
+
+	fn get_global_i64(&self, instance_idx: u32, name: &str) -> WResult<Option<i64>> {
+		self.sandbox_store
+			.borrow()
+			.instance(instance_idx)
+			.map(|i| i.get_global_i64(name))
+			.map_err(|e| e.to_string())
+	}
+
 	fn set_global_i64(&self, instance_idx: u32, name: &str, value: i64) -> WResult<u32> {
 		trace!(target: "sp-sandbox", "set_global_i64, instance_idx={}", instance_idx);
 

--- a/client/executor/wasmi/src/lib.rs
+++ b/client/executor/wasmi/src/lib.rs
@@ -369,6 +369,27 @@ impl Sandbox for FunctionExecutor {
 			.map_err(|e| e.to_string())
 	}
 
+	fn set_global_val(
+		&self,
+		instance_idx: u32,
+		name: &str,
+		value: sp_wasm_interface::Value,
+	) -> WResult<u32> {
+		trace!(target: "sp-sandbox", "set_global_val, instance_idx={}", instance_idx);
+
+		let instance =
+			self.sandbox_store.borrow().instance(instance_idx).map_err(|e| e.to_string())?;
+
+		let result = instance.set_global_val(name, value);
+
+		trace!(target: "sp-sandbox", "set_global_val, name={name}, value={value:?}, result={result:?}");
+		match result {
+			Ok(None) => Ok(sandbox_env::ERROR_GLOBALS_NOT_FOUND),
+			Ok(Some(_)) => Ok(sandbox_env::ERROR_GLOBALS_OK),
+			Err(_) => Ok(sandbox_env::ERROR_GLOBALS_OTHER),
+		}
+	}
+
 	fn set_global_i64(&self, instance_idx: u32, name: &str, value: i64) -> WResult<u32> {
 		trace!(target: "sp-sandbox", "set_global_i64, instance_idx={}", instance_idx);
 

--- a/client/executor/wasmtime/src/host.rs
+++ b/client/executor/wasmtime/src/host.rs
@@ -380,6 +380,26 @@ impl<'a> Sandbox for HostContext<'a> {
 			.map_err(|e| e.to_string())
 	}
 
+	fn set_global_val(
+		&self,
+		instance_idx: u32,
+		name: &str,
+		value: sp_wasm_interface::Value,
+	) -> sp_wasm_interface::Result<u32> {
+		trace!(target: "sp-sandbox", "set_global_val, instance_idx={}", instance_idx);
+
+		let instance = self.sandbox_store().instance(instance_idx).map_err(|e| e.to_string())?;
+
+		let result = instance.set_global_val(name, value);
+
+		trace!(target: "sp-sandbox", "set_global_val, name={name}, value={value:?}, result={result:?}");
+		match result {
+			Ok(None) => Ok(sandbox_env::ERROR_GLOBALS_NOT_FOUND),
+			Ok(Some(_)) => Ok(sandbox_env::ERROR_GLOBALS_OK),
+			Err(_) => Ok(sandbox_env::ERROR_GLOBALS_OTHER),
+		}
+	}
+
 	fn set_global_i64(
 		&self,
 		instance_idx: u32,

--- a/client/executor/wasmtime/src/host.rs
+++ b/client/executor/wasmtime/src/host.rs
@@ -358,6 +358,28 @@ impl<'a> Sandbox for HostContext<'a> {
 			.map_err(|e| e.to_string())
 	}
 
+	fn get_global_i32(
+		&self,
+		instance_idx: u32,
+		name: &str,
+	) -> sp_wasm_interface::Result<Option<i32>> {
+		self.sandbox_store()
+			.instance(instance_idx)
+			.map(|i| i.get_global_i32(name))
+			.map_err(|e| e.to_string())
+	}
+
+	fn get_global_i64(
+		&self,
+		instance_idx: u32,
+		name: &str,
+	) -> sp_wasm_interface::Result<Option<i64>> {
+		self.sandbox_store()
+			.instance(instance_idx)
+			.map(|i| i.get_global_i64(name))
+			.map_err(|e| e.to_string())
+	}
+
 	fn set_global_i64(
 		&self,
 		instance_idx: u32,

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -1722,6 +1722,17 @@ pub trait Sandbox {
 
 	/// Set the value of a global with the given `name`. The sandbox is determined by the given
 	/// `instance_idx`.
+	fn set_global_val(
+		&mut self,
+		instance_idx: u32,
+		name: &str,
+		value: sp_wasm_interface::Value,
+	) -> u32 {
+		self.sandbox()
+			.set_global_val(instance_idx, name, value)
+			.expect("Failed to set global in sandbox")
+	}
+
 	fn set_global_i64(&mut self, instance_idx: u32, name: &str, value: i64) -> u32 {
 		self.sandbox()
 			.set_global_i64(instance_idx, name, value)

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -1708,6 +1708,18 @@ pub trait Sandbox {
 			.expect("Failed to get global from sandbox")
 	}
 
+	fn get_global_i32(&mut self, instance_idx: u32, name: &str) -> Option<i32> {
+		self.sandbox()
+			.get_global_i32(instance_idx, name)
+			.expect("Failed to get global from sandbox")
+	}
+
+	fn get_global_i64(&mut self, instance_idx: u32, name: &str) -> Option<i64> {
+		self.sandbox()
+			.get_global_i64(instance_idx, name)
+			.expect("Failed to get global from sandbox")
+	}
+
 	/// Set the value of a global with the given `name`. The sandbox is determined by the given
 	/// `instance_idx`.
 	fn set_global_i64(&mut self, instance_idx: u32, name: &str, value: i64) -> u32 {

--- a/primitives/sandbox/src/embedded_executor.rs
+++ b/primitives/sandbox/src/embedded_executor.rs
@@ -261,6 +261,14 @@ impl super::InstanceGlobals for InstanceGlobals {
 		None
 	}
 
+	fn get_global_i32(&self, _name: &str) -> Option<i32> {
+		None
+	}
+
+	fn get_global_i64(&self, _name: &str) -> Option<i64> {
+		None
+	}
+
 	fn set_global_i64(&self, _name: &str, _value: i64) -> Result<(), super::GlobalsSetError> {
 		Err(super::GlobalsSetError::NotFound)
 	}

--- a/primitives/sandbox/src/embedded_executor.rs
+++ b/primitives/sandbox/src/embedded_executor.rs
@@ -69,7 +69,7 @@ impl super::SandboxMemory for Memory {
 	fn size(&self) -> u32 {
 		self.memref.current_size().0 as u32
 	}
-	
+
 	unsafe fn get_buff(&self) -> u64 {
 		self.memref.direct_access_mut().as_mut().as_mut_ptr() as usize as u64
 	}
@@ -267,6 +267,10 @@ impl super::InstanceGlobals for InstanceGlobals {
 
 	fn get_global_i64(&self, _name: &str) -> Option<i64> {
 		None
+	}
+
+	fn set_global_val(&self, _name: &str, _value: Value) -> Result<(), super::GlobalsSetError> {
+		Err(super::GlobalsSetError::NotFound)
 	}
 
 	fn set_global_i64(&self, _name: &str, _value: i64) -> Result<(), super::GlobalsSetError> {

--- a/primitives/sandbox/src/host_executor.rs
+++ b/primitives/sandbox/src/host_executor.rs
@@ -187,6 +187,14 @@ impl super::InstanceGlobals for InstanceGlobals {
 		self.instance_idx.and_then(|i| sandbox::get_global_val(i, name))
 	}
 
+	fn get_global_i32(&self, name: &str) -> Option<i32> {
+		self.instance_idx.and_then(|i| sandbox::get_global_i32(i, name))
+	}
+
+	fn get_global_i64(&self, name: &str) -> Option<i64> {
+		self.instance_idx.and_then(|i| sandbox::get_global_i64(i, name))
+	}
+
 	fn set_global_i64(&self, name: &str, value: i64) -> Result<(), super::GlobalsSetError> {
 		match self.instance_idx {
 			None => Err(super::GlobalsSetError::Other),

--- a/primitives/sandbox/src/host_executor.rs
+++ b/primitives/sandbox/src/host_executor.rs
@@ -195,6 +195,16 @@ impl super::InstanceGlobals for InstanceGlobals {
 		self.instance_idx.and_then(|i| sandbox::get_global_i64(i, name))
 	}
 
+	fn set_global_val(&self, name: &str, value: Value) -> Result<(), super::GlobalsSetError> {
+		match self.instance_idx {
+			None => Err(super::GlobalsSetError::Other),
+			Some(i) => match sandbox::set_global_val(i, name, value) {
+				env::ERROR_GLOBALS_OK => Ok(()),
+				env::ERROR_GLOBALS_NOT_FOUND => Err(super::GlobalsSetError::NotFound),
+				_ => Err(super::GlobalsSetError::Other),
+			},
+		}
+		
 	fn set_global_i64(&self, name: &str, value: i64) -> Result<(), super::GlobalsSetError> {
 		match self.instance_idx {
 			None => Err(super::GlobalsSetError::Other),

--- a/primitives/sandbox/src/lib.rs
+++ b/primitives/sandbox/src/lib.rs
@@ -234,6 +234,10 @@ pub trait InstanceGlobals: Sized + Clone {
 	/// Returns `Some(_)` if the global could be found.
 	fn get_global_val(&self, name: &str) -> Option<Value>;
 
+	fn get_global_i32(&self, name: &str) -> Option<i32>;
+
+	fn get_global_i64(&self, name: &str) -> Option<i64>;
+
 	/// Set the value of a global with the given `name`.
 	fn set_global_i64(&self, name: &str, value: i64) -> Result<(), GlobalsSetError>;
 }

--- a/primitives/sandbox/src/lib.rs
+++ b/primitives/sandbox/src/lib.rs
@@ -239,5 +239,7 @@ pub trait InstanceGlobals: Sized + Clone {
 	fn get_global_i64(&self, name: &str) -> Option<i64>;
 
 	/// Set the value of a global with the given `name`.
+	fn set_global_val(&self, name: &str, value: Value) -> Result<(), GlobalsSetError>;
+
 	fn set_global_i64(&self, name: &str, value: i64) -> Result<(), GlobalsSetError>;
 }

--- a/primitives/wasm-interface/src/lib.rs
+++ b/primitives/wasm-interface/src/lib.rs
@@ -388,6 +388,8 @@ pub trait Sandbox {
 	///
 	/// Returns `Some(_)` when the requested global variable could be found.
 	fn get_global_val(&self, instance_idx: u32, name: &str) -> Result<Option<Value>>;
+	fn get_global_i32(&self, instance_idx: u32, name: &str) -> Result<Option<i32>>;
+	fn get_global_i64(&self, instance_idx: u32, name: &str) -> Result<Option<i64>>;
 
 	/// Set the value of a global with the given `name`. The sandbox is determined by the
 	/// given `instance_idx` instance.

--- a/primitives/wasm-interface/src/lib.rs
+++ b/primitives/wasm-interface/src/lib.rs
@@ -388,13 +388,17 @@ pub trait Sandbox {
 	///
 	/// Returns `Some(_)` when the requested global variable could be found.
 	fn get_global_val(&self, instance_idx: u32, name: &str) -> Result<Option<Value>>;
+
 	fn get_global_i32(&self, instance_idx: u32, name: &str) -> Result<Option<i32>>;
+
 	fn get_global_i64(&self, instance_idx: u32, name: &str) -> Result<Option<i64>>;
 
 	/// Set the value of a global with the given `name`. The sandbox is determined by the
 	/// given `instance_idx` instance.
 	///
 	/// Returns `Ok(())` when the requested global variable could be modified.
+	fn set_global_val(&self, instance_idx: u32, name: &str, value: Value) -> Result<u32>;
+
 	fn set_global_i64(&self, instance_idx: u32, name: &str, value: i64) -> Result<u32>;
 
 	/// Returns size in wasm pages of memory with id `memory_id`.


### PR DESCRIPTION

- return primitive from `get_global` to avoid encoding `Value`
- return back `set_global` to support old runtimes