### PR TITLE
Make StorageTransactionCache clonable if type parameters permit

### DIFF
--- a/primitives/state-machine/src/overlayed_changes/mod.rs
+++ b/primitives/state-machine/src/overlayed_changes/mod.rs
@@ -197,6 +197,18 @@ impl<Transaction, H: Hasher> Default for StorageTransactionCache<Transaction, H>
 	}
 }
 
+impl<Transaction, H: Hasher> Clone for StorageTransactionCache<Transaction, H>
+where
+	Transaction: Clone,
+{
+	fn clone(&self) -> Self {
+		Self {
+			transaction: self.transaction.clone(),
+			transaction_storage_root: self.transaction_storage_root.clone(),
+		}
+	}
+}
+
 impl<Transaction: Default, H: Hasher> Default for StorageChanges<Transaction, H> {
 	fn default() -> Self {
 		Self {

--- a/primitives/state-machine/src/overlayed_changes/mod.rs
+++ b/primitives/state-machine/src/overlayed_changes/mod.rs
@@ -177,6 +177,7 @@ impl<Transaction, H: Hasher> StorageChanges<Transaction, H> {
 /// Storage transactions are calculated as part of the `storage_root`.
 /// These transactions can be reused for importing the block into the
 /// storage. So, we cache them to not require a recomputation of those transactions.
+#[derive(Clone)]
 pub struct StorageTransactionCache<Transaction, H: Hasher> {
 	/// Contains the changes for the main and the child storages as one transaction.
 	pub(crate) transaction: Option<Transaction>,
@@ -194,18 +195,6 @@ impl<Transaction, H: Hasher> StorageTransactionCache<Transaction, H> {
 impl<Transaction, H: Hasher> Default for StorageTransactionCache<Transaction, H> {
 	fn default() -> Self {
 		Self { transaction: None, transaction_storage_root: None }
-	}
-}
-
-impl<Transaction, H: Hasher> Clone for StorageTransactionCache<Transaction, H>
-where
-	Transaction: Clone,
-{
-	fn clone(&self) -> Self {
-		Self {
-			transaction: self.transaction.clone(),
-			transaction_storage_root: self.transaction_storage_root.clone(),
-		}
 	}
 }
 


### PR DESCRIPTION
We may need to be able to clone the associated `RuntimeApi` instance while cloning the block builder used to propose a block in order to be able to run the pseudo-inherent at the end of a block with a timeout in a separate thread on top of the overlay changes made by the extrinsics in this block, while keeping the old block builder intact in case we need to fall back to it if the timeout expires.
The `RuntimeApi` includes a reference to the `sp_state_machine::StorageTransactionCache` which doesn't implement `Clone` by default due to its dependent types, but in the real node all the type parameters involved are clonable.