### PR TITLE
fix(pallet-contracts): Add a handler for `MemoryGrow`.

### DIFF
--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -409,6 +409,8 @@ where
 			// Any other kind of a trap should result in a failure.
 			Err(sp_sandbox::Error::Execution) | Err(sp_sandbox::Error::OutOfBounds) =>
 				Err(Error::<E::T>::ContractTrapped)?,
+			Err(sp_sandbox::Error::MemoryGrow) =>
+				unreachable!("MemoryGrow returnes by the sandboxed runtime"),
 		}
 	}
 


### PR DESCRIPTION
This error kind was introduced with bb32803 (see #1), but pallet-contracts was not updated after adding it.

Note that adding a variant to an public exhaustive enum is a breaking change.
See https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new.