### PR TITLE
chore(wasm-interface): re-export `checked_range` from `-common`

### DIFF
--- a/primitives/wasm-interface-common/src/lib.rs
+++ b/primitives/wasm-interface-common/src/lib.rs
@@ -22,6 +22,8 @@
 use sp_std::borrow::Cow;
 use core::{mem, marker::PhantomData};
 
+pub mod util;
+
 #[cfg(feature = "wasmi")]
 pub use wasmi;
 

--- a/primitives/wasm-interface-common/src/util.rs
+++ b/primitives/wasm-interface-common/src/util.rs
@@ -1,0 +1,24 @@
+// This file is part of Gear.
+//
+// Copyright (C) 2021-2023 Gear Technologies Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+/// Construct a range from an offset to a data length after the offset.
+/// Returns None if the end of the range would exceed some maximum offset.
+pub fn checked_range(offset: usize, len: usize, max: usize) -> Option<Range<usize>> {
+	let end = offset.checked_add(len)?;
+	(end <= max).then(|| offset..end)
+}

--- a/primitives/wasm-interface-common/src/util.rs
+++ b/primitives/wasm-interface-common/src/util.rs
@@ -16,6 +16,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+use core::ops::Range;
+
 /// Construct a range from an offset to a data length after the offset.
 /// Returns None if the end of the range would exceed some maximum offset.
 pub fn checked_range(offset: usize, len: usize, max: usize) -> Option<Range<usize>> {

--- a/primitives/wasm-interface/src/util.rs
+++ b/primitives/wasm-interface/src/util.rs
@@ -18,13 +18,7 @@
 use super::*;
 use wasmtime::{AsContext, AsContextMut};
 use sp_std::ops::Range;
-
-/// Construct a range from an offset to a data length after the offset.
-/// Returns None if the end of the range would exceed some maximum offset.
-pub fn checked_range(offset: usize, len: usize, max: usize) -> Option<Range<usize>> {
-	let end = offset.checked_add(len)?;
-	(end <= max).then(|| offset..end)
-}
+pub use sp_wasm_interface_common::util::checked_range;
 
 pub fn write_memory_from(
     mut ctx: impl AsContextMut<Data = StoreData>,

--- a/primitives/wasm-interface/src/util.rs
+++ b/primitives/wasm-interface/src/util.rs
@@ -17,7 +17,6 @@
 
 use super::*;
 use wasmtime::{AsContext, AsContextMut};
-use sp_std::ops::Range;
 pub use sp_wasm_interface_common::util::checked_range;
 
 pub fn write_memory_from(


### PR DESCRIPTION
## Changes

- [x] move checked_range to `sp-wasm-interface-common`
- [x] re-export `sp-wasm-interface-common::util::checked_range` in `sp-wasm-interface::util`

the test is here https://github.com/gear-tech/gear/pull/3617
